### PR TITLE
Add PHP 8.0 to github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.2', '7.3', '7.4']
+        php-versions: ['7.2', '7.3', '7.4', '8.0']
         composer-flags: ['', '--prefer-lowest']
     steps:
       - uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "bin": ["bin/phpfci"],
     "require": {
-        "php": "7.2.* || 7.3.* || 7.4.*",
+        "php": ">=7.2",
         "ext-dom": "*",
         "ext-libxml": "*",
         "ext-xmlwriter": "*",
@@ -28,7 +28,7 @@
         "roave/security-advisories": "dev-master",
         "squizlabs/php_codesniffer": "^3.5",
         "phpmd/phpmd": "@stable",
-        "phpunit/phpunit": "8.5.*",
+        "phpunit/phpunit": "8.5.* || 9.4.*",
         "phpstan/phpstan-phpunit": "0.12.*",
         "phpstan/phpstan-strict-rules": "0.12.*",
         "phpstan/extension-installer": "1.0.*",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "phpstan/phpstan-strict-rules": "0.12.*",
         "phpstan/extension-installer": "1.0.*",
         "digitalrevolution/accessorpair-constraint": "^2.1",
-        "mikey179/vfsstream": "^1.6"
+        "mikey179/vfsstream": "^1.6.7"
     },
     "scripts": {
         "check": ["@check:phpstan", "@check:phpmd", "@check:phpcs"],

--- a/tests/Functional/Command/BaselineCommand/BaselineCommandTest.php
+++ b/tests/Functional/Command/BaselineCommand/BaselineCommandTest.php
@@ -26,6 +26,7 @@ class BaselineCommandTest extends TestCase
     }
 
     /**
+     * @coversNothing
      * @throws Exception
      */
     public function testBaselineCommand(): void

--- a/tests/Functional/Command/InspectCommand/InspectCommandTest.php
+++ b/tests/Functional/Command/InspectCommand/InspectCommandTest.php
@@ -25,6 +25,7 @@ class InspectCommandTest extends TestCase
     }
 
     /**
+     * @coversNothing
      * @throws Exception
      */
     public function testInspectCommand(): void


### PR DESCRIPTION
Add PHPUnit 9.4 to require-dev
- atm blocked by accessorpairconstraint phpunit version constraint
- PHPUnit 9 requires coverage settings on all testcases
-- Added coversNothing to keep same functionality