### PR TITLE
No uncovered methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,16 @@ File: `phpfci.xml`
 </phpfci>
 ```
 
+| Option                  | Required | Default  | Description                                   |
+|-------------------------|----------|----------|-----------------------------------------------|
+| min-coverage            | yes      | -        | The minimum global coverage                   |
+| allow-uncovered-methods | no       | false    | All methods should have atleast some coverage | 
+
+
 or generate a config file based on existing coverage results
 
 ```shell script
-php bin/phpfci baseline --baseDir /home/ci/workspace coverage.xml 
+php bin/phpfci baseline --baseDir /home/ci/workspace coverage.xml ./phpfci.xml
 ```
 
 The base directory will be subtracted from the filepaths in coverage.xml

--- a/resources/phpfci.xsd
+++ b/resources/phpfci.xsd
@@ -30,6 +30,7 @@
                 <xs:element ref="custom-coverage" maxOccurs="1" minOccurs="0"/>
             </xs:sequence>
             <xs:attribute name="min-coverage" type="percentage"/>
+            <xs:attribute name="allow-uncovered-methods" type="xs:boolean" default="false"/>
         </xs:complexType>
     </xs:element>
 </xs:schema>

--- a/src/Command/BaselineCommand.php
+++ b/src/Command/BaselineCommand.php
@@ -41,7 +41,7 @@ class BaselineCommand extends Command
         }
 
         $outputPath       = new SplFileInfo((string)$configArgument);
-        $baseDir          = $input->getOption('baseDir') ?? $outputPath->getPath() . '/';
+        $baseDir          = $input->getOption('baseDir') ?? $outputPath->getRealPath() . '/';
         $coverageFilePath = FileUtil::getExistingFile($input->getArgument('coverage'));
 
         if (is_string($baseDir) === false) {

--- a/src/Command/BaselineCommand.php
+++ b/src/Command/BaselineCommand.php
@@ -42,7 +42,7 @@ class BaselineCommand extends Command
         }
 
         $outputPath       = new SplFileInfo((string)$configArgument);
-        $baseDir          = $input->getOption('baseDir') ?? $outputPath->getRealPath() . '/';
+        $baseDir          = $input->getOption('baseDir') ?? $outputPath->getPath() . '/';
         $threshold        = $input->getOption('threshold');
         $coverageFilePath = FileUtil::getExistingFile($input->getArgument('coverage'));
 

--- a/src/Command/BaselineCommand.php
+++ b/src/Command/BaselineCommand.php
@@ -52,14 +52,14 @@ class BaselineCommand extends Command
             return Command::FAILURE;
         }
 
-        if (is_int($threshold) === false && is_numeric($threshold) === false) {
+        if (is_numeric($threshold) === false) {
             $output->writeln("--threshold should be a numeric value");
 
             return Command::FAILURE;
         }
 
         // default to 100% coverage
-        $config  = new InspectionConfig($baseDir, $threshold, false);
+        $config  = new InspectionConfig($baseDir, (int)$threshold, false);
         $metrics = MetricsFactory::getFileMetrics(DOMDocumentFactory::getDOMDocument($coverageFilePath));
 
         // analyzer

--- a/src/Command/BaselineCommand.php
+++ b/src/Command/BaselineCommand.php
@@ -27,7 +27,7 @@ class BaselineCommand extends Command
             ->setDescription("Generate phpfci.xml based on a given coverage.xml")
             ->addArgument('coverage', InputOption::VALUE_REQUIRED, 'Path to phpunit\'s coverage.xml')
             ->addArgument('config', InputOption::VALUE_REQUIRED, 'Path to write the configuration file')
-            ->addOption('coverage-threshold', '', InputOption::VALUE_REQUIRED, 'Minimum coverage threshold, defaults to 100', 100)
+            ->addOption('threshold', '', InputOption::VALUE_REQUIRED, 'Minimum coverage threshold, defaults to 100', 100)
             ->addOption('baseDir', '', InputOption::VALUE_REQUIRED, 'Base directory from where to determine the relative config paths');
     }
 
@@ -43,11 +43,17 @@ class BaselineCommand extends Command
 
         $outputPath       = new SplFileInfo((string)$configArgument);
         $baseDir          = $input->getOption('baseDir') ?? $outputPath->getRealPath() . '/';
-        $threshold        = (int)($input->getOption('coverage-threshold') ?? 100);
+        $threshold        = $input->getOption('threshold');
         $coverageFilePath = FileUtil::getExistingFile($input->getArgument('coverage'));
 
         if (is_string($baseDir) === false) {
             $output->writeln("--baseDir argument is not valid. Expecting string argument");
+
+            return Command::FAILURE;
+        }
+
+        if (is_int($threshold) === false && is_numeric($threshold) === false) {
+            $output->writeln("--threshold should be a numeric value");
 
             return Command::FAILURE;
         }

--- a/src/Command/BaselineCommand.php
+++ b/src/Command/BaselineCommand.php
@@ -27,6 +27,7 @@ class BaselineCommand extends Command
             ->setDescription("Generate phpfci.xml based on a given coverage.xml")
             ->addArgument('coverage', InputOption::VALUE_REQUIRED, 'Path to phpunit\'s coverage.xml')
             ->addArgument('config', InputOption::VALUE_REQUIRED, 'Path to write the configuration file')
+            ->addOption('coverage-threshold', '', InputOption::VALUE_REQUIRED, 'Minimum coverage threshold, defaults to 100', 100)
             ->addOption('baseDir', '', InputOption::VALUE_REQUIRED, 'Base directory from where to determine the relative config paths');
     }
 
@@ -42,6 +43,7 @@ class BaselineCommand extends Command
 
         $outputPath       = new SplFileInfo((string)$configArgument);
         $baseDir          = $input->getOption('baseDir') ?? $outputPath->getRealPath() . '/';
+        $threshold        = (int)($input->getOption('coverage-threshold') ?? 100);
         $coverageFilePath = FileUtil::getExistingFile($input->getArgument('coverage'));
 
         if (is_string($baseDir) === false) {
@@ -51,7 +53,7 @@ class BaselineCommand extends Command
         }
 
         // default to 100% coverage
-        $config  = new InspectionConfig($baseDir, 100);
+        $config  = new InspectionConfig($baseDir, $threshold, false);
         $metrics = MetricsFactory::getFileMetrics(DOMDocumentFactory::getDOMDocument($coverageFilePath));
 
         // analyzer

--- a/src/Command/BaselineCommand.php
+++ b/src/Command/BaselineCommand.php
@@ -52,7 +52,7 @@ class BaselineCommand extends Command
 
         // default to 100% coverage
         $config  = new InspectionConfig($baseDir, 100);
-        $metrics = MetricsFactory::getMetrics(DOMDocumentFactory::getDOMDocument($coverageFilePath));
+        $metrics = MetricsFactory::getFileMetrics(DOMDocumentFactory::getDOMDocument($coverageFilePath));
 
         // analyzer
         $failures = (new MetricsAnalyzer($metrics, $config))->analyze();

--- a/src/Command/InspectCommand.php
+++ b/src/Command/InspectCommand.php
@@ -34,7 +34,7 @@ class InspectCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $configPath       = FileUtil::getExistingFile($input->getOption('config') ?? FileUtil::findFilePath((string)getcwd(), self::CONFIG_FILES));
-        $baseDir          = $input->getOption('baseDir') ?? $configPath->getRealPath() . '/';
+        $baseDir          = $input->getOption('baseDir') ?? $configPath->getPath() . '/';
         $coverageFilePath = FileUtil::getExistingFile($input->getArgument('coverage'));
         $outputFilePath   = FileUtil::getFile($input->getArgument('output'));
         $schema           = dirname(__DIR__, 2) . '/resources/phpfci.xsd';

--- a/src/Command/InspectCommand.php
+++ b/src/Command/InspectCommand.php
@@ -34,7 +34,7 @@ class InspectCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $configPath       = FileUtil::getExistingFile($input->getOption('config') ?? FileUtil::findFilePath((string)getcwd(), self::CONFIG_FILES));
-        $baseDir          = $input->getOption('baseDir') ?? $configPath->getPath() . '/';
+        $baseDir          = $input->getOption('baseDir') ?? $configPath->getRealPath() . '/';
         $coverageFilePath = FileUtil::getExistingFile($input->getArgument('coverage'));
         $outputFilePath   = FileUtil::getFile($input->getArgument('output'));
         $schema           = dirname(__DIR__, 2) . '/resources/phpfci.xsd';

--- a/src/Command/InspectCommand.php
+++ b/src/Command/InspectCommand.php
@@ -48,7 +48,7 @@ class InspectCommand extends Command
         // gather data
         $domConfig = DOMDocumentFactory::getValidatedDOMDocument($configPath, $schema);
         $config    = InspectionConfigFactory::fromDOMDocument($baseDir, $domConfig);
-        $metrics   = MetricsFactory::getMetrics(DOMDocumentFactory::getDOMDocument($coverageFilePath));
+        $metrics   = MetricsFactory::getFileMetrics(DOMDocumentFactory::getDOMDocument($coverageFilePath));
 
         if (count($metrics) === 0) {
             $output->writeln("No metrics found in coverage file: " . $coverageFilePath->getPathname());

--- a/src/Lib/IO/InspectionConfigFactory.php
+++ b/src/Lib/IO/InspectionConfigFactory.php
@@ -15,7 +15,7 @@ class InspectionConfigFactory
     public static function fromDOMDocument(string $basePath, DOMDocument $doc): InspectionConfig
     {
         $xpath = new DOMXpath($doc);
-        [$minCoverage, $allowUncoveredMethods] = self::getConfiguration($xpath);
+        [$minCoverage, $isUncoveredAllowed] = self::getConfiguration($xpath);
 
         // find all custom coverage files
         $files     = [];
@@ -28,9 +28,12 @@ class InspectionConfigFactory
             }
         }
 
-        return new InspectionConfig($basePath, $minCoverage, $allowUncoveredMethods, $files);
+        return new InspectionConfig($basePath, $minCoverage, $isUncoveredAllowed, $files);
     }
 
+    /**
+     * @return array{int, bool}
+     */
     private static function getConfiguration(DOMXpath $xpath): array
     {
         // find global coverage settings
@@ -46,9 +49,9 @@ class InspectionConfigFactory
             // @codeCoverageIgnoreEnd
         }
 
-        $minCoverage           = (int)XMLUtil::getAttribute($node, 'min-coverage');
-        $allowUncoveredMethods = XMLUtil::getAttribute($node, 'allow-uncovered-methods') === "true";
+        $minCoverage        = (int)XMLUtil::getAttribute($node, 'min-coverage');
+        $isUncoveredAllowed = XMLUtil::getAttribute($node, 'allow-uncovered-methods') === "true";
 
-        return [$minCoverage, $allowUncoveredMethods];
+        return [$minCoverage, $isUncoveredAllowed];
     }
 }

--- a/src/Lib/IO/InspectionConfigFactory.php
+++ b/src/Lib/IO/InspectionConfigFactory.php
@@ -14,8 +14,8 @@ class InspectionConfigFactory
 {
     public static function fromDOMDocument(string $basePath, DOMDocument $doc): InspectionConfig
     {
-        $xpath       = new DOMXpath($doc);
-        $minCoverage = self::getMinimumCoverage($xpath);
+        $xpath = new DOMXpath($doc);
+        [$minCoverage, $allowUncoveredMethods] = self::getConfiguration($xpath);
 
         // find all custom coverage files
         $files     = [];
@@ -28,12 +28,12 @@ class InspectionConfigFactory
             }
         }
 
-        return new InspectionConfig($basePath, $minCoverage, $files);
+        return new InspectionConfig($basePath, $minCoverage, $allowUncoveredMethods, $files);
     }
 
-    private static function getMinimumCoverage(DOMXpath $xpath): int
+    private static function getConfiguration(DOMXpath $xpath): array
     {
-        // find global minimum coverage setting
+        // find global coverage settings
         $nodes = $xpath->query("/phpfci");
         if ($nodes === false || $nodes->count() === 0) {
             throw new RuntimeException('Missing `phpfci` in configuration file');
@@ -46,6 +46,9 @@ class InspectionConfigFactory
             // @codeCoverageIgnoreEnd
         }
 
-        return (int)XMLUtil::getAttribute($node, 'min-coverage');
+        $minCoverage           = (int)XMLUtil::getAttribute($node, 'min-coverage');
+        $allowUncoveredMethods = XMLUtil::getAttribute($node, 'allow-uncovered-methods') === "true";
+
+        return [$minCoverage, $allowUncoveredMethods];
     }
 }

--- a/src/Lib/IO/MetricsFactory.php
+++ b/src/Lib/IO/MetricsFactory.php
@@ -64,7 +64,7 @@ class MetricsFactory
 
         $metrics = [];
         foreach ($methodNodes as $methodNode) {
-            $methodName = XMLUtil::getAttribute($methodNode, 'name');
+            $methodName = XMLUtil::getAttribute($methodNode, 'name') ?? '';
             $lineNumber = (int)XMLUtil::getAttribute($methodNode, 'num');
             $count      = (int)XMLUtil::getAttribute($methodNode, 'count');
 

--- a/src/Lib/Metrics/FileMetricAnalyzer.php
+++ b/src/Lib/Metrics/FileMetricAnalyzer.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\CodeCoverageInspection\Lib\Metrics;
+
+use DigitalRevolution\CodeCoverageInspection\Model\Metric\FileMetric;
+use DigitalRevolution\CodeCoverageInspection\Model\Metric\MethodMetric;
+
+class FileMetricAnalyzer
+{
+    public static function getUncoveredMethodMetric(FileMetric $metric): ?MethodMetric
+    {
+        foreach ($metric->getMethods() as $method) {
+            if ($method->getCount() === 0) {
+                return $method;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Lib/Metrics/Inspection/AbstractInspection.php
+++ b/src/Lib/Metrics/Inspection/AbstractInspection.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\CodeCoverageInspection\Lib\Metrics\Inspection;
+
+use DigitalRevolution\CodeCoverageInspection\Model\Config\FileInspectionConfig;
+use DigitalRevolution\CodeCoverageInspection\Model\Config\InspectionConfig;
+use DigitalRevolution\CodeCoverageInspection\Model\Metric\Failure;
+use DigitalRevolution\CodeCoverageInspection\Model\Metric\FileMetric;
+
+abstract class AbstractInspection
+{
+    /** @var InspectionConfig */
+    protected $config;
+
+    public function __construct(InspectionConfig $config)
+    {
+        $this->config = $config;
+    }
+
+    abstract public function inspect(?FileInspectionConfig $fileConfig, FileMetric $metric): ?Failure;
+}

--- a/src/Lib/Metrics/Inspection/BelowCustomCoverageInspection.php
+++ b/src/Lib/Metrics/Inspection/BelowCustomCoverageInspection.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\CodeCoverageInspection\Lib\Metrics\Inspection;
+
+use DigitalRevolution\CodeCoverageInspection\Model\Config\FileInspectionConfig;
+use DigitalRevolution\CodeCoverageInspection\Model\Metric\Failure;
+use DigitalRevolution\CodeCoverageInspection\Model\Metric\FileMetric;
+
+/**
+ * File coverage is below custom coverage
+ */
+class BelowCustomCoverageInspection extends AbstractInspection
+{
+    public function inspect(?FileInspectionConfig $fileConfig, FileMetric $metric): ?Failure
+    {
+        if ($fileConfig !== null && $metric->getCoverage() < $fileConfig->getMinimumCoverage()) {
+            return new Failure($metric, $fileConfig->getMinimumCoverage(), Failure::CUSTOM_COVERAGE_TOO_LOW);
+        }
+
+        return null;
+    }
+}

--- a/src/Lib/Metrics/Inspection/BelowGlobalCoverageInspection.php
+++ b/src/Lib/Metrics/Inspection/BelowGlobalCoverageInspection.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\CodeCoverageInspection\Lib\Metrics\Inspection;
+
+use DigitalRevolution\CodeCoverageInspection\Model\Config\FileInspectionConfig;
+use DigitalRevolution\CodeCoverageInspection\Model\Metric\Failure;
+use DigitalRevolution\CodeCoverageInspection\Model\Metric\FileMetric;
+
+/**
+ * No custom coverage, and file is below global minimum coverage
+ */
+class BelowGlobalCoverageInspection extends AbstractInspection
+{
+    public function inspect(?FileInspectionConfig $fileConfig, FileMetric $metric): ?Failure
+    {
+        if ($fileConfig === null && $metric->getCoverage() < $this->config->getMinimumCoverage()) {
+            return new Failure($metric, $this->config->getMinimumCoverage(), Failure::GLOBAL_COVERAGE_TOO_LOW);
+        }
+
+        return null;
+    }
+}

--- a/src/Lib/Metrics/Inspection/CustomCoverageAboveGlobalInspection.php
+++ b/src/Lib/Metrics/Inspection/CustomCoverageAboveGlobalInspection.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\CodeCoverageInspection\Lib\Metrics\Inspection;
+
+use DigitalRevolution\CodeCoverageInspection\Lib\Metrics\FileMetricAnalyzer;
+use DigitalRevolution\CodeCoverageInspection\Model\Config\FileInspectionConfig;
+use DigitalRevolution\CodeCoverageInspection\Model\Metric\Failure;
+use DigitalRevolution\CodeCoverageInspection\Model\Metric\FileMetric;
+
+/**
+ * If a custom coverage is set, it should be below global coverage setting
+ */
+class CustomCoverageAboveGlobalInspection extends AbstractInspection
+{
+    public function inspect(?FileInspectionConfig $fileConfig, FileMetric $metric): ?Failure
+    {
+        $uncoveredMethod = FileMetricAnalyzer::getUncoveredMethodMetric($metric);
+
+        // custom coverage, but file is already above global coverage
+        if ($fileConfig !== null && $uncoveredMethod === null && $metric->getCoverage() >= $this->config->getMinimumCoverage()) {
+            return new Failure($metric, $fileConfig->getMinimumCoverage(), Failure::UNNECESSARY_CUSTOM_COVERAGE);
+        }
+
+        return null;
+    }
+}

--- a/src/Lib/Metrics/Inspection/UncoveredMethodsInspection.php
+++ b/src/Lib/Metrics/Inspection/UncoveredMethodsInspection.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\CodeCoverageInspection\Lib\Metrics\Inspection;
+
+use DigitalRevolution\CodeCoverageInspection\Lib\Metrics\FileMetricAnalyzer;
+use DigitalRevolution\CodeCoverageInspection\Model\Config\FileInspectionConfig;
+use DigitalRevolution\CodeCoverageInspection\Model\Metric\Failure;
+use DigitalRevolution\CodeCoverageInspection\Model\Metric\FileMetric;
+
+/**
+ * No custom coverage, and file has a method without any code coverage
+ */
+class UncoveredMethodsInspection extends AbstractInspection
+{
+    public function inspect(?FileInspectionConfig $fileConfig, FileMetric $metric): ?Failure
+    {
+        $uncoveredMethod = FileMetricAnalyzer::getUncoveredMethodMetric($metric);
+
+        if ($fileConfig === null && $uncoveredMethod !== null && $this->config->isUncoveredAllowed() === false) {
+            return new Failure($metric, $this->config->getMinimumCoverage(), Failure::MISSING_METHOD_COVERAGE, $uncoveredMethod->getLineNumber());
+        }
+
+        return null;
+    }
+}

--- a/src/Lib/Metrics/MetricsAnalyzer.php
+++ b/src/Lib/Metrics/MetricsAnalyzer.php
@@ -6,18 +6,18 @@ namespace DigitalRevolution\CodeCoverageInspection\Lib\Metrics;
 use DigitalRevolution\CodeCoverageInspection\Lib\Utility\FileUtil;
 use DigitalRevolution\CodeCoverageInspection\Model\Config\InspectionConfig;
 use DigitalRevolution\CodeCoverageInspection\Model\Metric\Failure;
-use DigitalRevolution\CodeCoverageInspection\Model\Metric\Metric;
+use DigitalRevolution\CodeCoverageInspection\Model\Metric\FileMetric;
 
 class MetricsAnalyzer
 {
-    /** @var Metric[] */
+    /** @var FileMetric[] */
     private $metrics;
 
     /** @var InspectionConfig */
     private $config;
 
     /**
-     * @param Metric[] $metrics
+     * @param FileMetric[] $metrics
      */
     public function __construct(array $metrics, InspectionConfig $config)
     {

--- a/src/Lib/Metrics/MetricsAnalyzer.php
+++ b/src/Lib/Metrics/MetricsAnalyzer.php
@@ -55,7 +55,7 @@ class MetricsAnalyzer
                 $failure = $inspection->inspect($fileConfig, $metric);
                 if ($failure !== null) {
                     $failures[] = $failure;
-                    continue;
+                    break;
                 }
             }
         }

--- a/src/Lib/Metrics/MetricsAnalyzer.php
+++ b/src/Lib/Metrics/MetricsAnalyzer.php
@@ -30,9 +30,9 @@ class MetricsAnalyzer
      */
     public function analyze(): array
     {
-        $failures              = [];
-        $minimumCoverage       = $this->config->getMinimumCoverage();
-        $allowUncoveredMethods = $this->config->isAllowUncoveredMethods();
+        $failures           = [];
+        $minimumCoverage    = $this->config->getMinimumCoverage();
+        $isUncoveredAllowed = $this->config->isUncoveredAllowed();
 
         foreach ($this->metrics as $metric) {
             $filepath        = FileUtil::getRelativePath($metric->getFilepath(), $this->config->getBasePath());
@@ -52,7 +52,7 @@ class MetricsAnalyzer
             }
 
             // no custom coverage, and file has a method without any code coverage
-            if ($fileConfig === null && $allowUncoveredMethods === false && $uncoveredMethod !== null) {
+            if ($fileConfig === null && $isUncoveredAllowed === false && $uncoveredMethod !== null) {
                 $failures[] = new Failure($metric, $minimumCoverage, Failure::MISSING_METHOD_COVERAGE, $uncoveredMethod->getLineNumber());
                 continue;
             }

--- a/src/Lib/Utility/FileUtil.php
+++ b/src/Lib/Utility/FileUtil.php
@@ -65,13 +65,10 @@ class FileUtil
 
     public static function writeFile(SplFileInfo $file, string $content): void
     {
-        $concurrentDirectory = $file->getPath();
-        if ($concurrentDirectory !== ''
-            && !is_dir($concurrentDirectory)
-            && !mkdir($concurrentDirectory, 0777, true)
-            && !is_dir($concurrentDirectory)) {
+        $dir = $file->getPath();
+        if ($dir !== '' && !is_dir($dir) && !mkdir($dir, 0777, true) && !is_dir($dir)) {
             // @codeCoverageIgnoreStart
-            throw new RuntimeException(sprintf('Failed to create directory "%s".', $concurrentDirectory));
+            throw new RuntimeException(sprintf('Failed to create directory "%s".', $dir));
             // @codeCoverageIgnoreEnd
         }
 

--- a/src/Lib/Utility/FileUtil.php
+++ b/src/Lib/Utility/FileUtil.php
@@ -66,7 +66,10 @@ class FileUtil
     public static function writeFile(SplFileInfo $file, string $content): void
     {
         $concurrentDirectory = $file->getPath();
-        if (!is_dir($concurrentDirectory) && !mkdir($concurrentDirectory, 0777, true) && !is_dir($concurrentDirectory)) {
+        if ($concurrentDirectory !== ''
+            && !is_dir($concurrentDirectory)
+            && !mkdir($concurrentDirectory, 0777, true)
+            && !is_dir($concurrentDirectory)) {
             // @codeCoverageIgnoreStart
             throw new RuntimeException(sprintf('Failed to create directory "%s".', $concurrentDirectory));
             // @codeCoverageIgnoreEnd

--- a/src/Model/Config/InspectionConfig.php
+++ b/src/Model/Config/InspectionConfig.php
@@ -22,9 +22,9 @@ class InspectionConfig
      */
     public function __construct(string $basePath, int $minimumCoverage, bool $uncoveredAllowed = false, array $customCoverage = [])
     {
-        $this->basePath           = $basePath;
-        $this->minimumCoverage    = $minimumCoverage;
-        $this->customCoverage     = $customCoverage;
+        $this->basePath         = $basePath;
+        $this->minimumCoverage  = $minimumCoverage;
+        $this->customCoverage   = $customCoverage;
         $this->uncoveredAllowed = $uncoveredAllowed;
     }
 

--- a/src/Model/Config/InspectionConfig.php
+++ b/src/Model/Config/InspectionConfig.php
@@ -9,7 +9,7 @@ class InspectionConfig
     private $minimumCoverage;
 
     /** @var bool */
-    private $isUncoveredAllowed;
+    private $uncoveredAllowed;
 
     /** @var FileInspectionConfig[] */
     private $customCoverage;
@@ -20,12 +20,12 @@ class InspectionConfig
     /**
      * @param FileInspectionConfig[] $customCoverage
      */
-    public function __construct(string $basePath, int $minimumCoverage, bool $isUncoveredAllowed = false, array $customCoverage = [])
+    public function __construct(string $basePath, int $minimumCoverage, bool $uncoveredAllowed = false, array $customCoverage = [])
     {
         $this->basePath           = $basePath;
         $this->minimumCoverage    = $minimumCoverage;
         $this->customCoverage     = $customCoverage;
-        $this->isUncoveredAllowed = $isUncoveredAllowed;
+        $this->uncoveredAllowed = $uncoveredAllowed;
     }
 
     public function getBasePath(): string
@@ -40,7 +40,7 @@ class InspectionConfig
 
     public function isUncoveredAllowed(): bool
     {
-        return $this->isUncoveredAllowed;
+        return $this->uncoveredAllowed;
     }
 
     public function getFileInspection(string $path): ?FileInspectionConfig

--- a/src/Model/Config/InspectionConfig.php
+++ b/src/Model/Config/InspectionConfig.php
@@ -8,6 +8,9 @@ class InspectionConfig
     /** @var int */
     private $minimumCoverage;
 
+    /** @var bool */
+    private $allowUncoveredMethods;
+
     /** @var FileInspectionConfig[] */
     private $customCoverage;
 
@@ -17,11 +20,12 @@ class InspectionConfig
     /**
      * @param FileInspectionConfig[] $customCoverage
      */
-    public function __construct(string $basePath, int $minimumCoverage, array $customCoverage = [])
+    public function __construct(string $basePath, int $minimumCoverage, bool $allowUncoveredMethods = false, array $customCoverage = [])
     {
         $this->basePath        = $basePath;
         $this->minimumCoverage = $minimumCoverage;
         $this->customCoverage  = $customCoverage;
+        $this->allowUncoveredMethods = $allowUncoveredMethods;
     }
 
     public function getBasePath(): string
@@ -32,6 +36,11 @@ class InspectionConfig
     public function getMinimumCoverage(): int
     {
         return $this->minimumCoverage;
+    }
+
+    public function isAllowUncoveredMethods(): bool
+    {
+        return $this->allowUncoveredMethods;
     }
 
     public function getFileInspection(string $path): ?FileInspectionConfig

--- a/src/Model/Config/InspectionConfig.php
+++ b/src/Model/Config/InspectionConfig.php
@@ -9,7 +9,7 @@ class InspectionConfig
     private $minimumCoverage;
 
     /** @var bool */
-    private $allowUncoveredMethods;
+    private $isUncoveredAllowed;
 
     /** @var FileInspectionConfig[] */
     private $customCoverage;
@@ -20,12 +20,12 @@ class InspectionConfig
     /**
      * @param FileInspectionConfig[] $customCoverage
      */
-    public function __construct(string $basePath, int $minimumCoverage, bool $allowUncoveredMethods = false, array $customCoverage = [])
+    public function __construct(string $basePath, int $minimumCoverage, bool $isUncoveredAllowed = false, array $customCoverage = [])
     {
-        $this->basePath        = $basePath;
-        $this->minimumCoverage = $minimumCoverage;
-        $this->customCoverage  = $customCoverage;
-        $this->allowUncoveredMethods = $allowUncoveredMethods;
+        $this->basePath           = $basePath;
+        $this->minimumCoverage    = $minimumCoverage;
+        $this->customCoverage     = $customCoverage;
+        $this->isUncoveredAllowed = $isUncoveredAllowed;
     }
 
     public function getBasePath(): string
@@ -38,9 +38,9 @@ class InspectionConfig
         return $this->minimumCoverage;
     }
 
-    public function isAllowUncoveredMethods(): bool
+    public function isUncoveredAllowed(): bool
     {
-        return $this->allowUncoveredMethods;
+        return $this->isUncoveredAllowed;
     }
 
     public function getFileInspection(string $path): ?FileInspectionConfig

--- a/src/Model/Metric/Failure.php
+++ b/src/Model/Metric/Failure.php
@@ -9,7 +9,7 @@ class Failure
     public const CUSTOM_COVERAGE_TOO_LOW     = 2;
     public const UNNECESSARY_CUSTOM_COVERAGE = 3;
 
-    /** @var Metric */
+    /** @var FileMetric */
     private $metric;
 
     /** @var int */
@@ -18,14 +18,14 @@ class Failure
     /** @var int */
     private $reason;
 
-    public function __construct(Metric $metric, int $minimumCoverage, int $reason)
+    public function __construct(FileMetric $metric, int $minimumCoverage, int $reason)
     {
         $this->metric          = $metric;
         $this->minimumCoverage = $minimumCoverage;
         $this->reason          = $reason;
     }
 
-    public function getMetric(): Metric
+    public function getMetric(): FileMetric
     {
         return $this->metric;
     }

--- a/src/Model/Metric/Failure.php
+++ b/src/Model/Metric/Failure.php
@@ -8,6 +8,7 @@ class Failure
     public const GLOBAL_COVERAGE_TOO_LOW     = 1;
     public const CUSTOM_COVERAGE_TOO_LOW     = 2;
     public const UNNECESSARY_CUSTOM_COVERAGE = 3;
+    public const MISSING_METHOD_COVERAGE     = 4;
 
     /** @var FileMetric */
     private $metric;
@@ -18,11 +19,15 @@ class Failure
     /** @var int */
     private $reason;
 
-    public function __construct(FileMetric $metric, int $minimumCoverage, int $reason)
+    /** @var int */
+    private $lineNumber;
+
+    public function __construct(FileMetric $metric, int $minimumCoverage, int $reason, int $lineNumber = 1)
     {
         $this->metric          = $metric;
         $this->minimumCoverage = $minimumCoverage;
         $this->reason          = $reason;
+        $this->lineNumber      = $lineNumber;
     }
 
     public function getMetric(): FileMetric
@@ -38,5 +43,10 @@ class Failure
     public function getReason(): int
     {
         return $this->reason;
+    }
+
+    public function getLineNumber(): int
+    {
+        return $this->lineNumber;
     }
 }

--- a/src/Model/Metric/FileMetric.php
+++ b/src/Model/Metric/FileMetric.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace DigitalRevolution\CodeCoverageInspection\Model\Metric;
 
-class Metric
+class FileMetric
 {
     /** @var string */
     private $filepath;
@@ -11,10 +11,17 @@ class Metric
     /** @var float */
     private $coverage;
 
-    public function __construct(string $filepath, float $coverage)
+    /** @var MethodMetric[] */
+    private $methods;
+
+    /**
+     * @param MethodMetric[] $methods
+     */
+    public function __construct(string $filepath, float $coverage, array $methods)
     {
         $this->filepath = $filepath;
         $this->coverage = $coverage;
+        $this->methods  = $methods;
     }
 
     public function getFilepath(): string
@@ -25,5 +32,13 @@ class Metric
     public function getCoverage(): float
     {
         return $this->coverage;
+    }
+
+    /**
+     * @return  MethodMetric[]
+     */
+    public function getMethods(): array
+    {
+        return $this->methods;
     }
 }

--- a/src/Model/Metric/MethodMetric.php
+++ b/src/Model/Metric/MethodMetric.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\CodeCoverageInspection\Model\Metric;
+
+class MethodMetric
+{
+    /** @var string */
+    private $methodName;
+
+    /** @var int */
+    private $lineNumber;
+
+    /** @var int */
+    private $count;
+
+    public function __construct(string $methodName, int $lineNumber, int $count)
+    {
+        $this->methodName = $methodName;
+        $this->lineNumber = $lineNumber;
+        $this->count      = $count;
+    }
+
+    public function getMethodName(): string
+    {
+        return $this->methodName;
+    }
+
+    public function getLineNumber(): int
+    {
+        return $this->lineNumber;
+    }
+
+    public function getCount(): int
+    {
+        return $this->count;
+    }
+}

--- a/src/Renderer/CheckStyleRenderer.php
+++ b/src/Renderer/CheckStyleRenderer.php
@@ -30,7 +30,7 @@ class CheckStyleRenderer
             $out->writeAttribute('name', $failure->getMetric()->getFilepath());
 
             $out->startElement('error');
-            $out->writeAttribute('line', (string)1);
+            $out->writeAttribute('line', (string)$failure->getLineNumber());
             $out->writeAttribute('column', (string)0);
             $out->writeAttribute('severity', 'error');
             $out->writeAttribute('message', $message);

--- a/src/Renderer/CheckStyleRenderer.php
+++ b/src/Renderer/CheckStyleRenderer.php
@@ -52,12 +52,14 @@ class CheckStyleRenderer
                 $message = "Project per file coverage is configured at %s%%. Current coverage is at %s%%. Improve coverage for this class.";
 
                 return sprintf($message, (string)$failure->getMinimumCoverage(), (string)$failure->getMetric()->getCoverage());
-
             case Failure::CUSTOM_COVERAGE_TOO_LOW:
                 $message = "Custom file coverage is configured at %s%%. Current coverage is at %s%%. Improve coverage for this class.";
 
                 return sprintf($message, (string)$failure->getMinimumCoverage(), (string)$failure->getMetric()->getCoverage());
+            case Failure::MISSING_METHOD_COVERAGE:
+                $message = "File coverage is above %s%%, but method has no coverage at all.";
 
+                return sprintf($message, (string)$config->getMinimumCoverage());
             case Failure::UNNECESSARY_CUSTOM_COVERAGE:
                 $message = "A custom file coverage is configured at %s%%, but the current file coverage %s%% exceeds the project coverage %s%%. ";
                 $message .= "Remove `%s` from phpfci.xml custom-coverage rules.";

--- a/tests/Unit/Lib/IO/InspectionConfigFactoryTest.php
+++ b/tests/Unit/Lib/IO/InspectionConfigFactoryTest.php
@@ -33,7 +33,7 @@ class InspectionConfigFactoryTest extends TestCase
         $config = InspectionConfigFactory::fromDOMDocument('/tmp/test', $dom);
         static::assertSame('/tmp/test', $config->getBasePath());
         static::assertSame(85, $config->getMinimumCoverage());
-        static::assertFalse($config->isAllowUncoveredMethods());
+        static::assertFalse($config->isUncoveredAllowed());
 
         $file = $config->getFileInspection('a/b/c');
         static::assertNotNull($file);
@@ -55,7 +55,7 @@ class InspectionConfigFactoryTest extends TestCase
         $dom->loadXML($xml);
 
         $config = InspectionConfigFactory::fromDOMDocument('/tmp/test', $dom);
-        static::assertTrue($config->isAllowUncoveredMethods());
+        static::assertTrue($config->isUncoveredAllowed());
     }
 
     /**
@@ -72,7 +72,7 @@ class InspectionConfigFactoryTest extends TestCase
         $dom->loadXML($xml);
 
         $config = InspectionConfigFactory::fromDOMDocument('/tmp/test', $dom);
-        static::assertFalse($config->isAllowUncoveredMethods());
+        static::assertFalse($config->isUncoveredAllowed());
     }
 
     /**

--- a/tests/Unit/Lib/IO/InspectionConfigFactoryTest.php
+++ b/tests/Unit/Lib/IO/InspectionConfigFactoryTest.php
@@ -15,7 +15,7 @@ class InspectionConfigFactoryTest extends TestCase
 {
     /**
      * @covers ::fromDOMDocument
-     * @covers ::getMinimumCoverage
+     * @covers ::getConfiguration
      */
     public function testFromDOMDocument(): void
     {
@@ -33,6 +33,7 @@ class InspectionConfigFactoryTest extends TestCase
         $config = InspectionConfigFactory::fromDOMDocument('/tmp/test', $dom);
         static::assertSame('/tmp/test', $config->getBasePath());
         static::assertSame(85, $config->getMinimumCoverage());
+        static::assertFalse($config->isAllowUncoveredMethods());
 
         $file = $config->getFileInspection('a/b/c');
         static::assertNotNull($file);
@@ -42,7 +43,41 @@ class InspectionConfigFactoryTest extends TestCase
 
     /**
      * @covers ::fromDOMDocument
-     * @covers ::getMinimumCoverage
+     * @covers ::getConfiguration
+     */
+    public function testFromDOMDocumentWithUncoveredMethodsAllowed(): void
+    {
+        $xml = '<?xml version="1.0" encoding="UTF-8"?>
+            <phpfci min-coverage="85" allow-uncovered-methods="true"></phpfci>
+        ';
+
+        $dom = new DOMDocument();
+        $dom->loadXML($xml);
+
+        $config = InspectionConfigFactory::fromDOMDocument('/tmp/test', $dom);
+        static::assertTrue($config->isAllowUncoveredMethods());
+    }
+
+    /**
+     * @covers ::fromDOMDocument
+     * @covers ::getConfiguration
+     */
+    public function testFromDOMDocumentWithUncoveredMethodsForcedDisallowed(): void
+    {
+        $xml = '<?xml version="1.0" encoding="UTF-8"?>
+            <phpfci min-coverage="85" allow-uncovered-methods="false"></phpfci>
+        ';
+
+        $dom = new DOMDocument();
+        $dom->loadXML($xml);
+
+        $config = InspectionConfigFactory::fromDOMDocument('/tmp/test', $dom);
+        static::assertFalse($config->isAllowUncoveredMethods());
+    }
+
+    /**
+     * @covers ::fromDOMDocument
+     * @covers ::getConfiguration
      */
     public function testFromDOMDocumentInvalidFormatThrowsException(): void
     {

--- a/tests/Unit/Lib/IO/MetricsFactoryTest.php
+++ b/tests/Unit/Lib/IO/MetricsFactoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace DigitalRevolution\CodeCoverageInspection\Tests\Unit\Lib\IO;
 
 use DigitalRevolution\CodeCoverageInspection\Lib\IO\MetricsFactory;
+use DigitalRevolution\CodeCoverageInspection\Model\Metric\MethodMetric;
 use DOMDocument;
 use PHPUnit\Framework\TestCase;
 
@@ -13,9 +14,10 @@ use PHPUnit\Framework\TestCase;
 class MetricsFactoryTest extends TestCase
 {
     /**
-     * @covers ::getMetrics
+     * @covers ::getFileMetrics
+     * @covers ::getMethodMetrics
      */
-    public function testGetMetrics(): void
+    public function testGetFileMetrics(): void
     {
         $xml = '<?xml version="1.0" encoding="UTF-8"?>
     <coverage generated="1598702199">
@@ -33,16 +35,50 @@ class MetricsFactoryTest extends TestCase
         $dom = new DOMDocument();
         $dom->loadXML($xml);
 
-        $metrics = MetricsFactory::getMetrics($dom);
+        $metrics = MetricsFactory::getFileMetrics($dom);
         static::assertCount(1, $metrics);
 
         $metric = reset($metrics);
         static::assertSame('/API/Example.php', $metric->getFilepath());
+        static::assertSame([], $metric->getMethods());
         static::assertSame(20.0, $metric->getCoverage());
     }
 
     /**
-     * @covers ::getMetrics
+     * @covers ::getFileMetrics
+     * @covers ::getMethodMetrics
+     */
+    public function testGetMethodMetrics(): void
+    {
+        $xml = '<?xml version="1.0" encoding="UTF-8"?>
+    <coverage generated="1598702199">
+        <project timestamp="1598702199">
+            <file name="/API/Example.php">
+                <metrics loc="11" ncloc="11" classes="0"
+                    methods="0" coveredmethods="0"
+                    conditionals="0" coveredconditionals="0"
+                    statements="50" coveredstatements="10"
+                    elements="0" coveredelements="0"/>
+                <line num="29" type="method" name="isFoobar" visibility="public" complexity="1" crap="1" count="1"/>
+                <line num="31" type="stmt" count="1"/>
+            </file>
+        </project>
+    </coverage>';
+
+        $dom = new DOMDocument();
+        $dom->loadXML($xml);
+
+        $metrics = MetricsFactory::getFileMetrics($dom);
+        static::assertCount(1, $metrics);
+
+        $metric = reset($metrics);
+        static::assertSame('/API/Example.php', $metric->getFilepath());
+        static::assertEquals([new MethodMetric('isFoobar', 29, 1)], $metric->getMethods());
+        static::assertSame(20.0, $metric->getCoverage());
+    }
+
+    /**
+     * @covers ::getFileMetrics
      */
     public function testGetMetricsEmptyXmlShouldReturnEmptyArray(): void
     {
@@ -54,6 +90,6 @@ class MetricsFactoryTest extends TestCase
         $dom = new DOMDocument();
         $dom->loadXML($xml);
 
-        static::assertCount(0, MetricsFactory::getMetrics($dom));
+        static::assertCount(0, MetricsFactory::getFileMetrics($dom));
     }
 }

--- a/tests/Unit/Lib/Metrics/FileMetricAnalyzerTest.php
+++ b/tests/Unit/Lib/Metrics/FileMetricAnalyzerTest.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\CodeCoverageInspection\Tests\Unit\Lib\Metrics;
+
+use DigitalRevolution\CodeCoverageInspection\Lib\Metrics\FileMetricAnalyzer;
+use DigitalRevolution\CodeCoverageInspection\Model\Metric\FileMetric;
+use DigitalRevolution\CodeCoverageInspection\Model\Metric\MethodMetric;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \DigitalRevolution\CodeCoverageInspection\Lib\Metrics\FileMetricAnalyzer
+ */
+class FileMetricAnalyzerTest extends TestCase
+{
+    /**
+     * @covers ::getUncoveredMethodMetric
+     */
+    public function testGetUncoveredMethodMetricShouldReturnNullForFileWithoutMethods(): void
+    {
+        $fileMetric = new FileMetric('/tmp/a/', 20, []);
+
+        static::assertNull(FileMetricAnalyzer::getUncoveredMethodMetric($fileMetric));
+    }
+
+    /**
+     * @covers ::getUncoveredMethodMetric
+     */
+    public function testGetUncoveredMethodMetricShouldReturnMethodWithoutCoverage(): void
+    {
+        $metricA    = new MethodMetric('A', 5, 1);
+        $metricB    = new MethodMetric('B', 6, 0);
+        $fileMetric = new FileMetric('/tmp/a/', 20, [$metricA, $metricB]);
+
+        // expect metric B
+        $result = FileMetricAnalyzer::getUncoveredMethodMetric($fileMetric);
+        static::assertSame($metricB, $result);
+    }
+
+    /**
+     * @covers ::getUncoveredMethodMetric
+     */
+    public function testGetUncoveredMethodMetricShouldReturnNullForMethodsThatAreCovered(): void
+    {
+        $metricA    = new MethodMetric('A', 5, 2);
+        $metricB    = new MethodMetric('B', 6, 3);
+        $fileMetric = new FileMetric('/tmp/a/', 20, [$metricA, $metricB]);
+
+        static::assertNull(FileMetricAnalyzer::getUncoveredMethodMetric($fileMetric));
+    }
+}

--- a/tests/Unit/Lib/Metrics/Inspection/BelowCustomCoverageInspectionTest.php
+++ b/tests/Unit/Lib/Metrics/Inspection/BelowCustomCoverageInspectionTest.php
@@ -22,7 +22,7 @@ class BelowCustomCoverageInspectionTest extends TestCase
 
     protected function setUp(): void
     {
-        $config     = new InspectionConfig('/tmp/b', 80);
+        $config     = new InspectionConfig('/tmp/', 80);
         $this->inspection = new BelowCustomCoverageInspection($config);
     }
 

--- a/tests/Unit/Lib/Metrics/Inspection/BelowCustomCoverageInspectionTest.php
+++ b/tests/Unit/Lib/Metrics/Inspection/BelowCustomCoverageInspectionTest.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\CodeCoverageInspection\Tests\Unit\Lib\Metrics\Inspection;
+
+use DigitalRevolution\CodeCoverageInspection\Lib\Metrics\Inspection\AbstractInspection;
+use DigitalRevolution\CodeCoverageInspection\Lib\Metrics\Inspection\BelowCustomCoverageInspection;
+use DigitalRevolution\CodeCoverageInspection\Model\Config\FileInspectionConfig;
+use DigitalRevolution\CodeCoverageInspection\Model\Config\InspectionConfig;
+use DigitalRevolution\CodeCoverageInspection\Model\Metric\Failure;
+use DigitalRevolution\CodeCoverageInspection\Model\Metric\FileMetric;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \DigitalRevolution\CodeCoverageInspection\Lib\Metrics\Inspection\BelowCustomCoverageInspection
+ * @covers \DigitalRevolution\CodeCoverageInspection\Lib\Metrics\Inspection\AbstractInspection::__construct
+ */
+class BelowCustomCoverageInspectionTest extends TestCase
+{
+    /** @var BelowCustomCoverageInspection */
+    private $inspection;
+
+    protected function setUp(): void
+    {
+        $config     = new InspectionConfig('/tmp/b', 80);
+        $this->inspection = new BelowCustomCoverageInspection($config);
+    }
+
+    /**
+     * @covers ::inspect
+     */
+    public function testInspectNoCustomCoverageShouldPass(): void
+    {
+        static::assertNull($this->inspection->inspect(null, new FileMetric('/tmp/b/', 0, [])));
+    }
+
+    /**
+     * Custom coverage 40%
+     * @covers ::inspect
+     */
+    public function testInspectCoverageBelowCustomCoverageShouldFail(): void
+    {
+        $fileConfig = new FileInspectionConfig('/tmp/b', 40);
+        $metric     = new FileMetric('/tmp/b', 20, []);
+
+        $failure = $this->inspection->inspect($fileConfig, $metric);
+        static::assertNotNull($failure);
+        static::assertSame(Failure::CUSTOM_COVERAGE_TOO_LOW, $failure->getReason());
+        static::assertSame(40, $failure->getMinimumCoverage());
+    }
+
+    /**
+     * @covers ::inspect
+     */
+    public function testInspectCoverageAboveCustomCoverageShouldPass(): void
+    {
+        $fileConfig = new FileInspectionConfig('/tmp/b', 40);
+        $metric     = new FileMetric('/tmp/b', 60, []);
+
+        static::assertNull($this->inspection->inspect($fileConfig, $metric));
+    }
+}

--- a/tests/Unit/Lib/Metrics/Inspection/BelowGlobalCoverageInspectionTest.php
+++ b/tests/Unit/Lib/Metrics/Inspection/BelowGlobalCoverageInspectionTest.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\CodeCoverageInspection\Tests\Unit\Lib\Metrics\Inspection;
+
+use DigitalRevolution\CodeCoverageInspection\Lib\Metrics\Inspection\BelowCustomCoverageInspection;
+use DigitalRevolution\CodeCoverageInspection\Lib\Metrics\Inspection\BelowGlobalCoverageInspection;
+use DigitalRevolution\CodeCoverageInspection\Model\Config\FileInspectionConfig;
+use DigitalRevolution\CodeCoverageInspection\Model\Config\InspectionConfig;
+use DigitalRevolution\CodeCoverageInspection\Model\Metric\Failure;
+use DigitalRevolution\CodeCoverageInspection\Model\Metric\FileMetric;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \DigitalRevolution\CodeCoverageInspection\Lib\Metrics\Inspection\BelowGlobalCoverageInspection
+ * @covers \DigitalRevolution\CodeCoverageInspection\Lib\Metrics\Inspection\AbstractInspection::__construct
+ */
+class BelowGlobalCoverageInspectionTest extends TestCase
+{
+    /** @var BelowCustomCoverageInspection */
+    private $inspection;
+
+    protected function setUp(): void
+    {
+        $config           = new InspectionConfig('/tmp/', 80);
+        $this->inspection = new BelowGlobalCoverageInspection($config);
+    }
+
+    /**
+     * @covers ::inspect
+     */
+    public function testInspectCustomCoverageShouldPass(): void
+    {
+        $fileConfig = new FileInspectionConfig('/tmp/a', 20);
+        static::assertNull($this->inspection->inspect($fileConfig, new FileMetric('/tmp/a', 20, [])));
+    }
+
+    /**
+     * @covers ::inspect
+     */
+    public function testInspectAboveGlobalCoverageShouldPass(): void
+    {
+        static::assertNull($this->inspection->inspect(null, new FileMetric('/tmp/a', 90, [])));
+    }
+
+    /**
+     * @covers ::inspect
+     */
+    public function testInspectBelowGlobalCoverageShouldFail(): void
+    {
+        $failure = $this->inspection->inspect(null, new FileMetric('/tmp/a', 70, []));
+        static::assertNotNull($failure);
+        static::assertSame(Failure::GLOBAL_COVERAGE_TOO_LOW, $failure->getReason());
+        static::assertSame(80, $failure->getMinimumCoverage());
+    }
+}

--- a/tests/Unit/Lib/Metrics/Inspection/BelowGlobalCoverageInspectionTest.php
+++ b/tests/Unit/Lib/Metrics/Inspection/BelowGlobalCoverageInspectionTest.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace DigitalRevolution\CodeCoverageInspection\Tests\Unit\Lib\Metrics\Inspection;
 
-use DigitalRevolution\CodeCoverageInspection\Lib\Metrics\Inspection\BelowCustomCoverageInspection;
 use DigitalRevolution\CodeCoverageInspection\Lib\Metrics\Inspection\BelowGlobalCoverageInspection;
 use DigitalRevolution\CodeCoverageInspection\Model\Config\FileInspectionConfig;
 use DigitalRevolution\CodeCoverageInspection\Model\Config\InspectionConfig;
@@ -17,7 +16,7 @@ use PHPUnit\Framework\TestCase;
  */
 class BelowGlobalCoverageInspectionTest extends TestCase
 {
-    /** @var BelowCustomCoverageInspection */
+    /** @var BelowGlobalCoverageInspection */
     private $inspection;
 
     protected function setUp(): void

--- a/tests/Unit/Lib/Metrics/Inspection/CustomCoverageAboveGlobalInspectionTest.php
+++ b/tests/Unit/Lib/Metrics/Inspection/CustomCoverageAboveGlobalInspectionTest.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace DigitalRevolution\CodeCoverageInspection\Tests\Unit\Lib\Metrics\Inspection;
 
-use DigitalRevolution\CodeCoverageInspection\Lib\Metrics\Inspection\BelowCustomCoverageInspection;
 use DigitalRevolution\CodeCoverageInspection\Lib\Metrics\Inspection\CustomCoverageAboveGlobalInspection;
 use DigitalRevolution\CodeCoverageInspection\Model\Config\FileInspectionConfig;
 use DigitalRevolution\CodeCoverageInspection\Model\Config\InspectionConfig;
@@ -17,7 +16,7 @@ use PHPUnit\Framework\TestCase;
  */
 class CustomCoverageAboveGlobalInspectionTest extends TestCase
 {
-    /** @var BelowCustomCoverageInspection */
+    /** @var CustomCoverageAboveGlobalInspection */
     private $inspection;
 
     protected function setUp(): void

--- a/tests/Unit/Lib/Metrics/Inspection/CustomCoverageAboveGlobalInspectionTest.php
+++ b/tests/Unit/Lib/Metrics/Inspection/CustomCoverageAboveGlobalInspectionTest.php
@@ -1,0 +1,61 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\CodeCoverageInspection\Tests\Unit\Lib\Metrics\Inspection;
+
+use DigitalRevolution\CodeCoverageInspection\Lib\Metrics\Inspection\BelowCustomCoverageInspection;
+use DigitalRevolution\CodeCoverageInspection\Lib\Metrics\Inspection\CustomCoverageAboveGlobalInspection;
+use DigitalRevolution\CodeCoverageInspection\Model\Config\FileInspectionConfig;
+use DigitalRevolution\CodeCoverageInspection\Model\Config\InspectionConfig;
+use DigitalRevolution\CodeCoverageInspection\Model\Metric\Failure;
+use DigitalRevolution\CodeCoverageInspection\Model\Metric\FileMetric;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \DigitalRevolution\CodeCoverageInspection\Lib\Metrics\Inspection\CustomCoverageAboveGlobalInspection
+ * @covers \DigitalRevolution\CodeCoverageInspection\Lib\Metrics\Inspection\AbstractInspection::__construct
+ */
+class CustomCoverageAboveGlobalInspectionTest extends TestCase
+{
+    /** @var BelowCustomCoverageInspection */
+    private $inspection;
+
+    protected function setUp(): void
+    {
+        $config           = new InspectionConfig('/tmp/', 80);
+        $this->inspection = new CustomCoverageAboveGlobalInspection($config);
+    }
+
+    /**
+     * @covers ::inspect
+     */
+    public function testInspectNoCustomCoverageShouldPass(): void
+    {
+        static::assertNull($this->inspection->inspect(null, new FileMetric('/tmp/b/', 0, [])));
+    }
+
+    /**
+     * @covers ::inspect
+     */
+    public function testInspectCoverageBelowGlobalCoverageShouldPass(): void
+    {
+        $fileConfig = new FileInspectionConfig('/tmp/b', 40);
+        $metric     = new FileMetric('/tmp/b', 70, []);
+
+        static::assertNull($this->inspection->inspect($fileConfig, $metric));
+    }
+
+    /**
+     * @covers ::inspect
+     */
+    public function testInspectCoverageAboveGlobalCoverageShouldFail(): void
+    {
+        $fileConfig = new FileInspectionConfig('/tmp/b', 40);
+        $metric     = new FileMetric('/tmp/b', 90, []);
+
+        $failure = $this->inspection->inspect($fileConfig, $metric);
+        static::assertNotNull($failure);
+        static::assertSame(Failure::UNNECESSARY_CUSTOM_COVERAGE, $failure->getReason());
+        static::assertSame(40, $failure->getMinimumCoverage());
+    }
+}

--- a/tests/Unit/Lib/Metrics/Inspection/UncoveredMethodsInspectionTest.php
+++ b/tests/Unit/Lib/Metrics/Inspection/UncoveredMethodsInspectionTest.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\CodeCoverageInspection\Tests\Unit\Lib\Metrics\Inspection;
+
+use DigitalRevolution\CodeCoverageInspection\Lib\Metrics\Inspection\UncoveredMethodsInspection;
+use DigitalRevolution\CodeCoverageInspection\Model\Config\FileInspectionConfig;
+use DigitalRevolution\CodeCoverageInspection\Model\Config\InspectionConfig;
+use DigitalRevolution\CodeCoverageInspection\Model\Metric\Failure;
+use DigitalRevolution\CodeCoverageInspection\Model\Metric\FileMetric;
+use DigitalRevolution\CodeCoverageInspection\Model\Metric\MethodMetric;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \DigitalRevolution\CodeCoverageInspection\Lib\Metrics\Inspection\UncoveredMethodsInspection
+ * @covers \DigitalRevolution\CodeCoverageInspection\Lib\Metrics\Inspection\AbstractInspection::__construct
+ */
+class UncoveredMethodsInspectionTest extends TestCase
+{
+    /** @var UncoveredMethodsInspection */
+    private $inspection;
+
+    protected function setUp(): void
+    {
+        $config           = new InspectionConfig('/tmp/', 80);
+        $this->inspection = new UncoveredMethodsInspection($config);
+    }
+
+    /**
+     * @covers ::inspect
+     */
+    public function testInspectCustomCoverageShouldPass(): void
+    {
+        $fileConfig = new FileInspectionConfig('/tmp/b', 40);
+        $metric     = new FileMetric('/tmp/b', 20, []);
+
+        static::assertNull($this->inspection->inspect($fileConfig, $metric));
+    }
+
+
+    /**
+     * @covers ::inspect
+     */
+    public function testInspectNoUncoveredMethodsShouldPass(): void
+    {
+        $metric = new FileMetric('/tmp/b', 20, [new MethodMetric('foobar', 200, 10)]);
+
+        static::assertNull($this->inspection->inspect(null, $metric));
+    }
+
+    /**
+     * @covers ::inspect
+     */
+    public function testInspectUncoveredMethodsShouldFail(): void
+    {
+        $metric = new FileMetric('/tmp/b', 20, [new MethodMetric('foobar', 200, 0)]);
+
+        $failure = $this->inspection->inspect(null, $metric);
+        static::assertNotNull($failure);
+        static::assertSame(Failure::MISSING_METHOD_COVERAGE, $failure->getReason());
+        static::assertSame(80, $failure->getMinimumCoverage());
+        static::assertSame(200, $failure->getLineNumber());
+    }
+}

--- a/tests/Unit/Lib/Metrics/MetricsAnalyzerTest.php
+++ b/tests/Unit/Lib/Metrics/MetricsAnalyzerTest.php
@@ -7,7 +7,7 @@ use DigitalRevolution\CodeCoverageInspection\Lib\Metrics\MetricsAnalyzer;
 use DigitalRevolution\CodeCoverageInspection\Model\Config\FileInspectionConfig;
 use DigitalRevolution\CodeCoverageInspection\Model\Config\InspectionConfig;
 use DigitalRevolution\CodeCoverageInspection\Model\Metric\Failure;
-use DigitalRevolution\CodeCoverageInspection\Model\Metric\Metric;
+use DigitalRevolution\CodeCoverageInspection\Model\Metric\FileMetric;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -21,7 +21,7 @@ class MetricsAnalyzerTest extends TestCase
      */
     public function testAnalyzeFileAboveMinimumShouldPass(): void
     {
-        $metrics[] = new Metric('/a/b/c/test.php', 80);
+        $metrics[] = new FileMetric('/a/b/c/test.php', 80, []);
         $config    = new InspectionConfig('/a/', 80);
 
         $analyzer = new MetricsAnalyzer($metrics, $config);
@@ -34,7 +34,7 @@ class MetricsAnalyzerTest extends TestCase
      */
     public function testAnalyzeFileBelowMinimumShouldFail(): void
     {
-        $metric  = new Metric('/a/b/c/test.php', 79.4);
+        $metric  = new FileMetric('/a/b/c/test.php', 79.4, []);
         $metrics = [$metric];
         $config  = new InspectionConfig('/a/', 80);
 
@@ -49,7 +49,7 @@ class MetricsAnalyzerTest extends TestCase
      */
     public function testAnalyzeFileWithCustomCoverageRuleShouldPass(): void
     {
-        $metrics[] = new Metric('/a/b/c/test.php', 45);
+        $metrics[] = new FileMetric('/a/b/c/test.php', 45, []);
         $config    = new InspectionConfig('/a/', 80, ['b/c/test.php' => new FileInspectionConfig('b/c/test.php', 40)]);
 
         $analyzer = new MetricsAnalyzer($metrics, $config);
@@ -62,7 +62,7 @@ class MetricsAnalyzerTest extends TestCase
      */
     public function testAnalyzeFileWithCustomCoverageRuleShouldFail(): void
     {
-        $metric  = new Metric('/a/b/c/test.php', 45);
+        $metric  = new FileMetric('/a/b/c/test.php', 45, []);
         $metrics = [$metric];
         $config  = new InspectionConfig('/a/', 80, ['b/c/test.php' => new FileInspectionConfig('b/c/test.php', 50)]);
 
@@ -77,7 +77,7 @@ class MetricsAnalyzerTest extends TestCase
      */
     public function testAnalyzeFileWithCustomCoverageAboveGlobalCoverageShouldFail(): void
     {
-        $metric  = new Metric('/a/b/c/test.php', 90);
+        $metric  = new FileMetric('/a/b/c/test.php', 90, []);
         $metrics = [$metric];
         $config  = new InspectionConfig('/a/', 80, ['b/c/test.php' => new FileInspectionConfig('b/c/test.php', 50)]);
 

--- a/tests/Unit/Lib/Metrics/MetricsAnalyzerTest.php
+++ b/tests/Unit/Lib/Metrics/MetricsAnalyzerTest.php
@@ -50,7 +50,7 @@ class MetricsAnalyzerTest extends TestCase
     public function testAnalyzeFileWithCustomCoverageRuleShouldPass(): void
     {
         $metrics[] = new FileMetric('/a/b/c/test.php', 45, []);
-        $config    = new InspectionConfig('/a/', 80, ['b/c/test.php' => new FileInspectionConfig('b/c/test.php', 40)]);
+        $config    = new InspectionConfig('/a/', 80, false, ['b/c/test.php' => new FileInspectionConfig('b/c/test.php', 40)]);
 
         $analyzer = new MetricsAnalyzer($metrics, $config);
         $result   = $analyzer->analyze();
@@ -64,7 +64,7 @@ class MetricsAnalyzerTest extends TestCase
     {
         $metric  = new FileMetric('/a/b/c/test.php', 45, []);
         $metrics = [$metric];
-        $config  = new InspectionConfig('/a/', 80, ['b/c/test.php' => new FileInspectionConfig('b/c/test.php', 50)]);
+        $config  = new InspectionConfig('/a/', 80, false, ['b/c/test.php' => new FileInspectionConfig('b/c/test.php', 50)]);
 
         $analyzer = new MetricsAnalyzer($metrics, $config);
         $result   = $analyzer->analyze();
@@ -79,7 +79,7 @@ class MetricsAnalyzerTest extends TestCase
     {
         $metric  = new FileMetric('/a/b/c/test.php', 90, []);
         $metrics = [$metric];
-        $config  = new InspectionConfig('/a/', 80, ['b/c/test.php' => new FileInspectionConfig('b/c/test.php', 50)]);
+        $config  = new InspectionConfig('/a/', 80, false, ['b/c/test.php' => new FileInspectionConfig('b/c/test.php', 50)]);
 
         $analyzer = new MetricsAnalyzer($metrics, $config);
         $result   = $analyzer->analyze();

--- a/tests/Unit/Model/Config/InspectionConfigTest.php
+++ b/tests/Unit/Model/Config/InspectionConfigTest.php
@@ -30,7 +30,7 @@ class InspectionConfigTest extends TestCase
     public function testGetFileInspection(): void
     {
         $fileConfig = new FileInspectionConfig('foobar', 50);
-        $config     = new InspectionConfig('/base/path', 20, ['foobar' => $fileConfig]);
+        $config     = new InspectionConfig('/base/path', 20, false, ['foobar' => $fileConfig]);
 
         static::assertNull($config->getFileInspection('invalid'));
         static::assertSame($fileConfig, $config->getFileInspection('foobar'));

--- a/tests/Unit/Model/Metric/FileMetricTest.php
+++ b/tests/Unit/Model/Metric/FileMetricTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 namespace DigitalRevolution\CodeCoverageInspection\Tests\Unit\Model\Metric;
 
 use DigitalRevolution\AccessorPairConstraint\AccessorPairAsserter;
-use DigitalRevolution\CodeCoverageInspection\Model\Metric\Metric;
+use DigitalRevolution\CodeCoverageInspection\Model\Metric\FileMetric;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @coversDefaultClass \DigitalRevolution\CodeCoverageInspection\Model\Metric\Metric
+ * @coversDefaultClass \DigitalRevolution\CodeCoverageInspection\Model\Metric\FileMetric
  */
-class MetricTest extends TestCase
+class FileMetricTest extends TestCase
 {
     use AccessorPairAsserter;
 
@@ -19,6 +19,6 @@ class MetricTest extends TestCase
      */
     public function testAccessors(): void
     {
-        static::assertAccessorPairs(Metric::class);
+        static::assertAccessorPairs(FileMetric::class);
     }
 }

--- a/tests/Unit/Model/Metric/MethodMetricTest.php
+++ b/tests/Unit/Model/Metric/MethodMetricTest.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\CodeCoverageInspection\Tests\Unit\Model\Metric;
+
+use DigitalRevolution\AccessorPairConstraint\AccessorPairAsserter;
+use DigitalRevolution\CodeCoverageInspection\Model\Metric\MethodMetric;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \DigitalRevolution\CodeCoverageInspection\Model\Metric\MethodMetric
+ * @covers ::__construct
+ */
+class MethodMetricTest extends TestCase
+{
+    use AccessorPairAsserter;
+
+    /**
+     * @covers ::<public>
+     */
+    public function testAccessors(): void
+    {
+        static::assertAccessorPairs(MethodMetric::class);
+    }
+}

--- a/tests/Unit/Renderer/CheckStyleRendererTest.php
+++ b/tests/Unit/Renderer/CheckStyleRendererTest.php
@@ -5,7 +5,7 @@ namespace DigitalRevolution\CodeCoverageInspection\Tests\Unit\Renderer;
 
 use DigitalRevolution\CodeCoverageInspection\Model\Config\InspectionConfig;
 use DigitalRevolution\CodeCoverageInspection\Model\Metric\Failure;
-use DigitalRevolution\CodeCoverageInspection\Model\Metric\Metric;
+use DigitalRevolution\CodeCoverageInspection\Model\Metric\FileMetric;
 use DigitalRevolution\CodeCoverageInspection\Renderer\CheckStyleRenderer;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
@@ -22,7 +22,7 @@ class CheckStyleRendererTest extends TestCase
     public function testRenderGlobalCoverageTooLow(): void
     {
         $config  = new InspectionConfig('', 80);
-        $metric  = new Metric('/foo/bar/file.php', 48.3);
+        $metric  = new FileMetric('/foo/bar/file.php', 48.3, []);
         $failure = new Failure($metric, 80, Failure::GLOBAL_COVERAGE_TOO_LOW);
 
         $checkStyle = new CheckStyleRenderer();
@@ -47,7 +47,7 @@ class CheckStyleRendererTest extends TestCase
     public function testRenderFileCoverageTooLow(): void
     {
         $config  = new InspectionConfig('', 80);
-        $metric  = new Metric('/foo/bar/file.php', 48.3);
+        $metric  = new FileMetric('/foo/bar/file.php', 48.3, []);
         $failure = new Failure($metric, 60, Failure::CUSTOM_COVERAGE_TOO_LOW);
 
         $checkStyle = new CheckStyleRenderer();
@@ -72,7 +72,7 @@ class CheckStyleRendererTest extends TestCase
     public function testRenderUnnecessaryFileCoverage(): void
     {
         $config  = new InspectionConfig('', 80);
-        $metric  = new Metric('/foo/bar/file.php', 85.3);
+        $metric  = new FileMetric('/foo/bar/file.php', 85.3, []);
         $failure = new Failure($metric, 60, Failure::UNNECESSARY_CUSTOM_COVERAGE);
 
         $checkStyle = new CheckStyleRenderer();
@@ -98,7 +98,7 @@ class CheckStyleRendererTest extends TestCase
     public function testRenderInvalidReasonThrowsException(): void
     {
         $config     = new InspectionConfig('', 80);
-        $metric     = new Metric('/foo/bar/file.php', 85.3);
+        $metric     = new FileMetric('/foo/bar/file.php', 85.3, []);
         $failure    = new Failure($metric, 60, -4);
         $checkStyle = new CheckStyleRenderer();
 

--- a/tests/Unit/Renderer/CheckStyleRendererTest.php
+++ b/tests/Unit/Renderer/CheckStyleRendererTest.php
@@ -73,7 +73,7 @@ class CheckStyleRendererTest extends TestCase
     {
         $config  = new InspectionConfig('', 80);
         $metric  = new FileMetric('/foo/bar/file.php', 85.3, []);
-        $failure = new Failure($metric, 60, Failure::UNNECESSARY_CUSTOM_COVERAGE, 20);
+        $failure = new Failure($metric, 60, Failure::MISSING_METHOD_COVERAGE, 20);
 
         $checkStyle = new CheckStyleRenderer();
         $result     = $checkStyle->render($config, [$failure]);
@@ -82,8 +82,7 @@ class CheckStyleRendererTest extends TestCase
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" .
             "<checkstyle version=\"3.5.5\">\n" .
             " <file name=\"/foo/bar/file.php\">\n" .
-            "  <error line=\"20\" column=\"0\" severity=\"error\" message=\"A custom file coverage is configured at 60%, but the current " .
-            "file coverage 85.3% exceeds the project coverage 80%. Remove `/foo/bar/file.php` from phpfci.xml custom-coverage rules.\"" .
+            "  <error line=\"20\" column=\"0\" severity=\"error\" message=\"File coverage is above 80%, but method has no coverage at all.\"" .
             " source=\"phpunit-file-coverage-inspection\"/>\n" .
             " </file>\n" .
             "</checkstyle>\n",

--- a/tests/Unit/Renderer/CheckStyleRendererTest.php
+++ b/tests/Unit/Renderer/CheckStyleRendererTest.php
@@ -69,6 +69,32 @@ class CheckStyleRendererTest extends TestCase
      * @covers ::render
      * @covers ::formatReason
      */
+    public function testRenderMissingMethodCoverage(): void
+    {
+        $config  = new InspectionConfig('', 80);
+        $metric  = new FileMetric('/foo/bar/file.php', 85.3, []);
+        $failure = new Failure($metric, 60, Failure::UNNECESSARY_CUSTOM_COVERAGE, 20);
+
+        $checkStyle = new CheckStyleRenderer();
+        $result     = $checkStyle->render($config, [$failure]);
+
+        static::assertSame(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" .
+            "<checkstyle version=\"3.5.5\">\n" .
+            " <file name=\"/foo/bar/file.php\">\n" .
+            "  <error line=\"20\" column=\"0\" severity=\"error\" message=\"A custom file coverage is configured at 60%, but the current " .
+            "file coverage 85.3% exceeds the project coverage 80%. Remove `/foo/bar/file.php` from phpfci.xml custom-coverage rules.\"" .
+            " source=\"phpunit-file-coverage-inspection\"/>\n" .
+            " </file>\n" .
+            "</checkstyle>\n",
+            $result
+        );
+    }
+
+    /**
+     * @covers ::render
+     * @covers ::formatReason
+     */
     public function testRenderUnnecessaryFileCoverage(): void
     {
         $config  = new InspectionConfig('', 80);

--- a/tests/Unit/Renderer/ConfigFileRendererTest.php
+++ b/tests/Unit/Renderer/ConfigFileRendererTest.php
@@ -5,7 +5,7 @@ namespace DigitalRevolution\CodeCoverageInspection\Tests\Unit\Renderer;
 
 use DigitalRevolution\CodeCoverageInspection\Model\Config\InspectionConfig;
 use DigitalRevolution\CodeCoverageInspection\Model\Metric\Failure;
-use DigitalRevolution\CodeCoverageInspection\Model\Metric\Metric;
+use DigitalRevolution\CodeCoverageInspection\Model\Metric\FileMetric;
 use DigitalRevolution\CodeCoverageInspection\Renderer\ConfigFileRenderer;
 use PHPUnit\Framework\TestCase;
 
@@ -20,7 +20,7 @@ class ConfigFileRendererTest extends TestCase
     public function testWrite(): void
     {
         $config  = new InspectionConfig('/foo/', 100);
-        $metric  = new Metric('/foo/bar/file.php', 48.3);
+        $metric  = new FileMetric('/foo/bar/file.php', 48.3, []);
         $failure = new Failure($metric, 60, Failure::GLOBAL_COVERAGE_TOO_LOW);
 
         $checkStyle = new ConfigFileRenderer();


### PR DESCRIPTION
Added allow-uncovered-methods option to the configuration xml
By default allow-uncovered-methods is set to false and will trigger error if coverage is above the threshold, but a method has 0 coverage.
Additionally fixed some small issues with directories in the baseline command.