### PR TITLE
Add gitlab error renderer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.2', '7.3', '7.4', '8.0']
+        php-versions: ['7.4', '8.0']
         composer-flags: ['', '--prefer-lowest']
     steps:
       - uses: actions/checkout@v2
@@ -35,7 +35,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.2
+          php-version: 7.4
           coverage: none
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress --no-suggest

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This package makes sure that that doesn't happen anymore and coverage is calcula
 
 ## Supported formats
 * Input: clover coverage.xml
-* Output: checkstyle
+* Output: checkstyle or gitlab
 
 ## Installation
 Include the library as dependency in your own project via: 
@@ -54,10 +54,15 @@ The base directory will be subtracted from the filepaths in coverage.xml
 
 ## Usage
 
+Checkstyle format:
 ```shell script
-php vendor/bin/phpfci inspect coverage.xml reports/checkstyle.xml
+php vendor/bin/phpfci inspect coverage.xml reports/checkstyle.xml --report=checkstyle
 ```
- 
+
+Gitlab format:
+```shell script
+php vendor/bin/phpfci inspect coverage.xml reports/gitlab.errors.json --report=gitlab
+```
 
 ## About us
 

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "roave/security-advisories": "dev-master",
         "squizlabs/php_codesniffer": "^3.5",
         "phpmd/phpmd": "@stable",
-        "phpunit/phpunit": "9.4.*",
+        "phpunit/phpunit": "9.5.*",
         "phpstan/phpstan-phpunit": "0.12.*",
         "phpstan/phpstan-strict-rules": "0.12.*",
         "phpstan/extension-installer": "1.0.*",

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,9 @@
     },
     "bin": ["bin/phpfci"],
     "require": {
-        "php": ">=7.2",
+        "php": ">=7.4",
         "ext-dom": "*",
+        "ext-json": "*",
         "ext-libxml": "*",
         "ext-xmlwriter": "*",
         "symfony/console": "^5.1"

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "roave/security-advisories": "dev-master",
         "squizlabs/php_codesniffer": "^3.5",
         "phpmd/phpmd": "@stable",
-        "phpunit/phpunit": "8.5.* || 9.4.*",
+        "phpunit/phpunit": "9.4.*",
         "phpstan/phpstan-phpunit": "0.12.*",
         "phpstan/phpstan-strict-rules": "0.12.*",
         "phpstan/extension-installer": "1.0.*",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          forceCoversAnnotation="true"
          failOnRisky="true"
@@ -19,9 +19,9 @@
             <directory>tests/Unit</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+    <coverage processUncoveredFiles="true">
+        <include>
             <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>

--- a/src/Lib/Metrics/Inspection/AbstractInspection.php
+++ b/src/Lib/Metrics/Inspection/AbstractInspection.php
@@ -10,8 +10,7 @@ use DigitalRevolution\CodeCoverageInspection\Model\Metric\FileMetric;
 
 abstract class AbstractInspection
 {
-    /** @var InspectionConfig */
-    protected $config;
+    protected InspectionConfig $config;
 
     public function __construct(InspectionConfig $config)
     {

--- a/src/Lib/Metrics/MetricsAnalyzer.php
+++ b/src/Lib/Metrics/MetricsAnalyzer.php
@@ -16,13 +16,12 @@ use DigitalRevolution\CodeCoverageInspection\Model\Metric\FileMetric;
 class MetricsAnalyzer
 {
     /** @var FileMetric[] */
-    private $metrics;
+    private array $metrics;
 
-    /** @var InspectionConfig */
-    private $config;
+    private InspectionConfig $config;
 
     /** @var AbstractInspection[] */
-    private $inspections;
+    private array $inspections;
 
     /**
      * @param FileMetric[] $metrics

--- a/src/Model/Config/FileInspectionConfig.php
+++ b/src/Model/Config/FileInspectionConfig.php
@@ -5,11 +5,8 @@ namespace DigitalRevolution\CodeCoverageInspection\Model\Config;
 
 class FileInspectionConfig
 {
-    /** @var string */
-    private $path;
-
-    /** @var int */
-    private $minimumCoverage;
+    private string $path;
+    private int $minimumCoverage;
 
     public function __construct(string $path, int $minimumCoverage)
     {

--- a/src/Model/Config/InspectionConfig.php
+++ b/src/Model/Config/InspectionConfig.php
@@ -5,17 +5,11 @@ namespace DigitalRevolution\CodeCoverageInspection\Model\Config;
 
 class InspectionConfig
 {
-    /** @var int */
-    private $minimumCoverage;
-
-    /** @var bool */
-    private $uncoveredAllowed;
-
+    private int $minimumCoverage;
+    private bool $uncoveredAllowed;
     /** @var FileInspectionConfig[] */
-    private $customCoverage;
-
-    /** @var string */
-    private $basePath;
+    private array $customCoverage;
+    private string $basePath;
 
     /**
      * @param FileInspectionConfig[] $customCoverage

--- a/src/Model/Metric/Failure.php
+++ b/src/Model/Metric/Failure.php
@@ -10,17 +10,10 @@ class Failure
     public const UNNECESSARY_CUSTOM_COVERAGE = 3;
     public const MISSING_METHOD_COVERAGE     = 4;
 
-    /** @var FileMetric */
-    private $metric;
-
-    /** @var int */
-    private $minimumCoverage;
-
-    /** @var int */
-    private $reason;
-
-    /** @var int */
-    private $lineNumber;
+    private FileMetric $metric;
+    private int $minimumCoverage;
+    private int $reason;
+    private int $lineNumber;
 
     public function __construct(FileMetric $metric, int $minimumCoverage, int $reason, int $lineNumber = 1)
     {

--- a/src/Model/Metric/FileMetric.php
+++ b/src/Model/Metric/FileMetric.php
@@ -5,14 +5,10 @@ namespace DigitalRevolution\CodeCoverageInspection\Model\Metric;
 
 class FileMetric
 {
-    /** @var string */
-    private $filepath;
-
-    /** @var float */
-    private $coverage;
-
+    private string $filepath;
+    private float  $coverage;
     /** @var MethodMetric[] */
-    private $methods;
+    private array $methods;
 
     /**
      * @param MethodMetric[] $methods

--- a/src/Model/Metric/MethodMetric.php
+++ b/src/Model/Metric/MethodMetric.php
@@ -5,14 +5,9 @@ namespace DigitalRevolution\CodeCoverageInspection\Model\Metric;
 
 class MethodMetric
 {
-    /** @var string */
-    private $methodName;
-
-    /** @var int */
-    private $lineNumber;
-
-    /** @var int */
-    private $count;
+    private string $methodName;
+    private int    $lineNumber;
+    private int    $count;
 
     public function __construct(string $methodName, int $lineNumber, int $count)
     {

--- a/src/Renderer/CheckStyleRenderer.php
+++ b/src/Renderer/CheckStyleRenderer.php
@@ -24,7 +24,7 @@ class CheckStyleRenderer
         $out->writeAttribute('version', '3.5.5');
 
         foreach ($failures as $failure) {
-            $message = $this->formatReason($config, $failure);
+            $message = RendererHelper::renderReason($config, $failure);
 
             $out->startElement('file');
             $out->writeAttribute('name', $failure->getMetric()->getFilepath());
@@ -45,34 +45,4 @@ class CheckStyleRenderer
         return $out->flush();
     }
 
-    private function formatReason(InspectionConfig $config, Failure $failure): string
-    {
-        switch ($failure->getReason()) {
-            case Failure::GLOBAL_COVERAGE_TOO_LOW:
-                $message = "Project per file coverage is configured at %s%%. Current coverage is at %s%%. Improve coverage for this class.";
-
-                return sprintf($message, (string)$failure->getMinimumCoverage(), (string)$failure->getMetric()->getCoverage());
-            case Failure::CUSTOM_COVERAGE_TOO_LOW:
-                $message = "Custom file coverage is configured at %s%%. Current coverage is at %s%%. Improve coverage for this class.";
-
-                return sprintf($message, (string)$failure->getMinimumCoverage(), (string)$failure->getMetric()->getCoverage());
-            case Failure::MISSING_METHOD_COVERAGE:
-                $message = "File coverage is above %s%%, but method has no coverage at all.";
-
-                return sprintf($message, (string)$config->getMinimumCoverage());
-            case Failure::UNNECESSARY_CUSTOM_COVERAGE:
-                $message = "A custom file coverage is configured at %s%%, but the current file coverage %s%% exceeds the project coverage %s%%. ";
-                $message .= "Remove `%s` from phpfci.xml custom-coverage rules.";
-
-                return sprintf(
-                    $message,
-                    (string)$failure->getMinimumCoverage(),
-                    (string)$failure->getMetric()->getCoverage(),
-                    (string)$config->getMinimumCoverage(),
-                    $failure->getMetric()->getFilepath()
-                );
-            default:
-                throw new RuntimeException('Unknown failure reason: ' . $failure->getReason());
-        }
-    }
 }

--- a/src/Renderer/CheckStyleRenderer.php
+++ b/src/Renderer/CheckStyleRenderer.php
@@ -44,5 +44,4 @@ class CheckStyleRenderer
 
         return $out->flush();
     }
-
 }

--- a/src/Renderer/GitlabErrorRenderer.php
+++ b/src/Renderer/GitlabErrorRenderer.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\CodeCoverageInspection\Renderer;
+
+use DigitalRevolution\CodeCoverageInspection\Model\Config\InspectionConfig;
+use DigitalRevolution\CodeCoverageInspection\Model\Metric\Failure;
+use JsonException;
+
+/**
+ * @see https://docs.gitlab.com/ee/user/project/merge_requests/code_quality.html#implementing-a-custom-tool
+ */
+class GitlabErrorRenderer
+{
+    /**
+     * @param Failure[] $failures
+     *
+     * @throws JsonException
+     */
+    public function render(InspectionConfig $config, array $failures): string
+    {
+        $errors = [];
+
+        foreach ($failures as $failure) {
+            $message = RendererHelper::renderReason($config, $failure);
+
+            $error = [
+                'description' => $message,
+                'fingerprint' => hash(
+                    'sha256',
+                    implode(
+                        [
+                            $failure->getMetric()->getFilepath(),
+                            $failure->getLineNumber(),
+                            $message,
+                        ]
+                    )
+                ),
+                'severity'    => 'major',
+                'location'    => [
+                    'path' => $failure->getMetric()->getFilepath(),
+                    'lines' => [
+                        'begin' => $failure->getLineNumber(),
+                    ],
+                ],
+            ];
+
+            $errors[] = $error;
+        }
+
+        return json_encode($errors, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT);
+    }
+}

--- a/src/Renderer/RendererHelper.php
+++ b/src/Renderer/RendererHelper.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\CodeCoverageInspection\Renderer;
+
+use DigitalRevolution\CodeCoverageInspection\Model\Config\InspectionConfig;
+use DigitalRevolution\CodeCoverageInspection\Model\Metric\Failure;
+use RuntimeException;
+
+class RendererHelper
+{
+    public static function renderReason(InspectionConfig $config, Failure $failure): string
+    {
+        switch ($failure->getReason()) {
+            case Failure::GLOBAL_COVERAGE_TOO_LOW:
+                $message = "Project per file coverage is configured at %s%%. Current coverage is at %s%%. Improve coverage for this class.";
+
+                return sprintf($message, (string)$failure->getMinimumCoverage(), (string)$failure->getMetric()->getCoverage());
+            case Failure::CUSTOM_COVERAGE_TOO_LOW:
+                $message = "Custom file coverage is configured at %s%%. Current coverage is at %s%%. Improve coverage for this class.";
+
+                return sprintf($message, (string)$failure->getMinimumCoverage(), (string)$failure->getMetric()->getCoverage());
+            case Failure::MISSING_METHOD_COVERAGE:
+                $message = "File coverage is above %s%%, but method has no coverage at all.";
+
+                return sprintf($message, (string)$config->getMinimumCoverage());
+            case Failure::UNNECESSARY_CUSTOM_COVERAGE:
+                $message = "A custom file coverage is configured at %s%%, but the current file coverage %s%% exceeds the project coverage %s%%. ";
+                $message .= "Remove `%s` from phpfci.xml custom-coverage rules.";
+
+                return sprintf(
+                    $message,
+                    (string)$failure->getMinimumCoverage(),
+                    (string)$failure->getMetric()->getCoverage(),
+                    (string)$config->getMinimumCoverage(),
+                    $failure->getMetric()->getFilepath()
+                );
+            default:
+                throw new RuntimeException('Unknown failure reason: ' . $failure->getReason());
+        }
+    }
+}

--- a/tests/Unit/Lib/IO/DOMDocumentFactoryTest.php
+++ b/tests/Unit/Lib/IO/DOMDocumentFactoryTest.php
@@ -16,11 +16,8 @@ class DOMDocumentFactoryTest extends TestCase
     /** @var resource */
     private $file;
 
-    /** @var SplFileInfo */
-    private $fileInfo;
-
-    /** @var string */
-    private $schemaPath;
+    private SplFileInfo $fileInfo;
+    private string $schemaPath;
 
     protected function setUp(): void
     {
@@ -87,7 +84,7 @@ class DOMDocumentFactoryTest extends TestCase
         fwrite($this->file, $xml);
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage("is not a valid value of the atomic");
+        $this->expectExceptionMessage("Xml doesn't have the correct format");
         DOMDocumentFactory::getValidatedDOMDocument($this->fileInfo, $this->schemaPath);
     }
 

--- a/tests/Unit/Renderer/CheckStyleRendererTest.php
+++ b/tests/Unit/Renderer/CheckStyleRendererTest.php
@@ -17,7 +17,6 @@ class CheckStyleRendererTest extends TestCase
 {
     /**
      * @covers ::render
-     * @covers ::formatReason
      */
     public function testRenderGlobalCoverageTooLow(): void
     {
@@ -42,7 +41,6 @@ class CheckStyleRendererTest extends TestCase
 
     /**
      * @covers ::render
-     * @covers ::formatReason
      */
     public function testRenderFileCoverageTooLow(): void
     {
@@ -67,7 +65,6 @@ class CheckStyleRendererTest extends TestCase
 
     /**
      * @covers ::render
-     * @covers ::formatReason
      */
     public function testRenderMissingMethodCoverage(): void
     {
@@ -92,7 +89,6 @@ class CheckStyleRendererTest extends TestCase
 
     /**
      * @covers ::render
-     * @covers ::formatReason
      */
     public function testRenderUnnecessaryFileCoverage(): void
     {
@@ -118,7 +114,6 @@ class CheckStyleRendererTest extends TestCase
 
     /**
      * @covers ::render
-     * @covers ::formatReason
      */
     public function testRenderInvalidReasonThrowsException(): void
     {

--- a/tests/Unit/Renderer/GitlabErrorRendererTest.php
+++ b/tests/Unit/Renderer/GitlabErrorRendererTest.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\CodeCoverageInspection\Tests\Unit\Renderer;
+
+use DigitalRevolution\CodeCoverageInspection\Model\Config\InspectionConfig;
+use DigitalRevolution\CodeCoverageInspection\Model\Metric\Failure;
+use DigitalRevolution\CodeCoverageInspection\Model\Metric\FileMetric;
+use DigitalRevolution\CodeCoverageInspection\Renderer\GitlabErrorRenderer;
+use JsonException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \DigitalRevolution\CodeCoverageInspection\Renderer\GitlabErrorRenderer
+ */
+class GitlabErrorRendererTest extends TestCase
+{
+    /**
+     * @covers ::render
+     * @throws JsonException
+     */
+    public function testRender(): void
+    {
+        $config  = new InspectionConfig('', 80);
+        $metric  = new FileMetric('/foo/bar/file.php', 48.3, []);
+        $failure = new Failure($metric, 80, Failure::GLOBAL_COVERAGE_TOO_LOW);
+
+        $checkStyle = new GitlabErrorRenderer();
+        $result     = $checkStyle->render($config, [$failure]);
+
+        static::assertSame(
+            [
+                [
+                    'description' => 'Project per file coverage is configured at 80%. Current coverage is at 48.3%. Improve coverage for this class.',
+                    'fingerprint' => 'b798f95fb1a0d73279de8818d0403284c8fe97d7eae224631b741784d5c4b9d1',
+                    'severity'    => 'major',
+                    'location'    => [
+                        'path'  => '/foo/bar/file.php',
+                        'lines' => [
+                            'begin' => 1
+                        ]
+                    ]
+                ]
+            ],
+            json_decode($result, true, 512, JSON_THROW_ON_ERROR)
+        );
+    }
+}

--- a/tests/Unit/Renderer/RendererHelperTest.php
+++ b/tests/Unit/Renderer/RendererHelperTest.php
@@ -8,6 +8,7 @@ use DigitalRevolution\CodeCoverageInspection\Model\Metric\Failure;
 use DigitalRevolution\CodeCoverageInspection\Model\Metric\FileMetric;
 use DigitalRevolution\CodeCoverageInspection\Renderer\RendererHelper;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 /**
  * @coversDefaultClass \DigitalRevolution\CodeCoverageInspection\Renderer\RendererHelper
@@ -71,5 +72,17 @@ class RendererHelperTest extends TestCase
             'exceeds the project coverage 80%. Remove `foobar` from phpfci.xml custom-coverage rules.',
             $message
         );
+    }
+
+    /**
+     * @covers ::renderReason
+     */
+    public function testRenderReasonShouldThrowExceptionWhenInvalid(): void
+    {
+        $metric  = new FileMetric('foobar', 70, []);
+        $failure = new Failure($metric, 30, 9999, 5);
+
+        $this->expectException(RuntimeException::class);
+        RendererHelper::renderReason($this->config, $failure);
     }
 }

--- a/tests/Unit/Renderer/RendererHelperTest.php
+++ b/tests/Unit/Renderer/RendererHelperTest.php
@@ -1,0 +1,75 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\CodeCoverageInspection\Tests\Unit\Renderer;
+
+use DigitalRevolution\CodeCoverageInspection\Model\Config\InspectionConfig;
+use DigitalRevolution\CodeCoverageInspection\Model\Metric\Failure;
+use DigitalRevolution\CodeCoverageInspection\Model\Metric\FileMetric;
+use DigitalRevolution\CodeCoverageInspection\Renderer\RendererHelper;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \DigitalRevolution\CodeCoverageInspection\Renderer\RendererHelper
+ */
+class RendererHelperTest extends TestCase
+{
+    private InspectionConfig $config;
+
+    protected function setUp(): void
+    {
+        $this->config = new InspectionConfig('base-path', 80);
+    }
+
+    /**
+     * @covers ::renderReason
+     */
+    public function testRenderReasonGlobalCoverageTooLow(): void
+    {
+        $metric  = new FileMetric('foobar', 80, []);
+        $failure = new Failure($metric, 20, Failure::GLOBAL_COVERAGE_TOO_LOW, 5);
+
+        $message = RendererHelper::renderReason($this->config, $failure);
+        static::assertSame('Project per file coverage is configured at 20%. Current coverage is at 80%. Improve coverage for this class.', $message);
+    }
+
+    /**
+     * @covers ::renderReason
+     */
+    public function testRenderReasonCustomCoverageTooLow(): void
+    {
+        $metric  = new FileMetric('foobar', 70, []);
+        $failure = new Failure($metric, 30, Failure::CUSTOM_COVERAGE_TOO_LOW, 5);
+
+        $message = RendererHelper::renderReason($this->config, $failure);
+        static::assertSame('Custom file coverage is configured at 30%. Current coverage is at 70%. Improve coverage for this class.', $message);
+    }
+
+    /**
+     * @covers ::renderReason
+     */
+    public function testRenderReasonMissingMethodCoverage(): void
+    {
+        $metric  = new FileMetric('foobar', 70, []);
+        $failure = new Failure($metric, 30, Failure::MISSING_METHOD_COVERAGE, 5);
+
+        $message = RendererHelper::renderReason($this->config, $failure);
+        static::assertSame('File coverage is above 80%, but method has no coverage at all.', $message);
+    }
+
+    /**
+     * @covers ::renderReason
+     */
+    public function testRenderReasonUnnecessaryCustomCoverage(): void
+    {
+        $metric  = new FileMetric('foobar', 70, []);
+        $failure = new Failure($metric, 30, Failure::UNNECESSARY_CUSTOM_COVERAGE, 5);
+
+        $message = RendererHelper::renderReason($this->config, $failure);
+        static::assertSame(
+            'A custom file coverage is configured at 30%, but the current file coverage 70% ' .
+            'exceeds the project coverage 80%. Remove `foobar` from phpfci.xml custom-coverage rules.',
+            $message
+        );
+    }
+}


### PR DESCRIPTION
Feature: add gitlab error renderer format

Added new renderer for gitlab format
Added new cli option --report. Options `checkstyle|gitlab`, defaults to checkstyle.
Added coverage