### PR TITLE
Add ability to raise the exit code when there are failures found.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,17 @@ Gitlab format:
 php vendor/bin/phpfci inspect coverage.xml reports/gitlab.errors.json --report=gitlab
 ```
 
+## Command line arguments
+
+| Option                    | Values                 | Description                                           |
+|---------------------------|------------------------|-------------------------------------------------------| 
+| `argument 1`              | `inspect`, `baseline`  | the command to execute.                               |
+| `argument 2`              | `coverage.xml`         | the phpunit clover coverage input file.               |
+| `argument 3`              | `phpfci.xml`           | the output file to write to.                          |
+| `--report=<report-style>` | `gitlab`, `checkstyle` | the output format. If absent will default to console. |
+| `--config=<path-to-file>` | `phpfci.xml`           | the path to the config file.                          |
+| `--exit-code-on-failure`  | -                      | Set exit code to `1` when there are failures.         |
+
 ## About us
 
 At 123inkt (Part of Digital Revolution B.V.), every day more than 30 developers are working on improving our internal ERP and our several shops. Do you want to join us? [We are looking for developers](https://www.123inkt.nl/page/werken_ict.html).

--- a/src/Command/InspectCommand.php
+++ b/src/Command/InspectCommand.php
@@ -32,7 +32,8 @@ class InspectCommand extends Command
             ->addArgument('output', InputOption::VALUE_REQUIRED, 'Path to write inspections report file to')
             ->addOption('config', 'c', InputOption::VALUE_REQUIRED, 'Path to configuration file. Optional')
             ->addOption('baseDir', '', InputOption::VALUE_REQUIRED, 'Base directory from where to determine the relative config paths')
-            ->addOption('report', '', InputOption::VALUE_REQUIRED, 'output format, either checkstyle or gitlab', 'checkstyle');
+            ->addOption('report', '', InputOption::VALUE_REQUIRED, 'output format, either checkstyle or gitlab', 'checkstyle')
+            ->addOption('exit-code-on-failure', '', InputOption::VALUE_NONE, 'If failures, exit with failure exit code');
     }
 
     /**
@@ -76,6 +77,11 @@ class InspectCommand extends Command
                 break;
             default:
                 throw new InvalidArgumentException('Invalid report argument: ' . $input->getOption('report'));
+        }
+
+        // raise exit code on failure
+        if (count($failures) > 0 && $input->hasOption('exit-code-on-failure')) {
+            return Command::FAILURE;
         }
 
         return Command::SUCCESS;

--- a/src/Command/InspectCommand.php
+++ b/src/Command/InspectCommand.php
@@ -80,7 +80,7 @@ class InspectCommand extends Command
         }
 
         // raise exit code on failure
-        if (count($failures) > 0 && $input->hasOption('exit-code-on-failure')) {
+        if (count($failures) > 0 && $input->getOption('exit-code-on-failure')) {
             return Command::FAILURE;
         }
 

--- a/src/Command/InspectCommand.php
+++ b/src/Command/InspectCommand.php
@@ -80,7 +80,7 @@ class InspectCommand extends Command
         }
 
         // raise exit code on failure
-        if (count($failures) > 0 && $input->getOption('exit-code-on-failure')) {
+        if (count($failures) > 0 && $input->getOption('exit-code-on-failure') !== false) {
             return Command::FAILURE;
         }
 

--- a/src/Renderer/CheckStyleRenderer.php
+++ b/src/Renderer/CheckStyleRenderer.php
@@ -5,7 +5,6 @@ namespace DigitalRevolution\CodeCoverageInspection\Renderer;
 
 use DigitalRevolution\CodeCoverageInspection\Model\Config\InspectionConfig;
 use DigitalRevolution\CodeCoverageInspection\Model\Metric\Failure;
-use RuntimeException;
 use XMLWriter;
 
 class CheckStyleRenderer

--- a/tests/Functional/Command/InspectCommand/InspectCommandTest.php
+++ b/tests/Functional/Command/InspectCommand/InspectCommandTest.php
@@ -15,8 +15,7 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 
 class InspectCommandTest extends TestCase
 {
-    /** @var vfsStreamDirectory */
-    private $fileSystem;
+    private vfsStreamDirectory $fileSystem;
 
     protected function setUp(): void
     {
@@ -26,9 +25,10 @@ class InspectCommandTest extends TestCase
 
     /**
      * @coversNothing
+     * @dataProvider dataProvider
      * @throws Exception
      */
-    public function testInspectCommand(): void
+    public function testInspectCommand(array $flags, int $exitStatus): void
     {
         // prepare data files
         $configPath   = __DIR__ . '/Data/phpfci.xml';
@@ -39,11 +39,11 @@ class InspectCommandTest extends TestCase
 
         // prepare command
         $command = new InspectCommand();
-        $input   = new ArgvInput(['phpfci', '--config', $configPath, '--baseDir', $baseDir, $coveragePath, $output]);
+        $input   = new ArgvInput(array_merge(['phpfci', '--config', $configPath, '--baseDir', $baseDir, $coveragePath, $output], $flags));
         $output  = new ConsoleOutput();
 
         // run test case
-        static::assertSame(Command::SUCCESS, $command->run($input, $output));
+        static::assertSame($exitStatus, $command->run($input, $output));
         static::assertTrue($this->fileSystem->hasChild('checkstyle.xml'));
 
         // check output
@@ -52,5 +52,13 @@ class InspectCommandTest extends TestCase
         $result     = $resultFile->getContent();
 
         static::assertSame($expected, $result);
+    }
+
+    public function dataProvider(): array
+    {
+        return [
+            'standard exit code'   => [[], Command::SUCCESS],
+            'exit code on failure' => [['--exit-code-on-failure'], Command::FAILURE]
+        ];
     }
 }


### PR DESCRIPTION
Added option `--exit-code-on-failure`.
When set will set the exit code to `1` when the inspection resulted in one or more failures.
Updated readme to document all command line arguments.