### PR TITLE
Only report actual uncovered methods.

### DIFF
--- a/src/Renderer/RendererHelper.php
+++ b/src/Renderer/RendererHelper.php
@@ -22,7 +22,12 @@ class RendererHelper
                 return sprintf($message, (string)$failure->getMinimumCoverage(), (string)$failure->getMetric()->getCoverage());
             case Failure::MISSING_METHOD_COVERAGE:
                 $message     = "File coverage is above %s%%, but method(s) `%s` has/have no coverage at all.";
-                $methodNames = array_map(static fn($method): string => $method->getMethodName(), $failure->getMetric()->getMethods());
+                $methodNames = array_filter(
+                    array_map(
+                        static fn($method): ?string => $method->getCount() === 0 ? $method->getMethodName() : null,
+                        $failure->getMetric()->getMethods()
+                    )
+                );
 
                 return sprintf($message, (string)$config->getMinimumCoverage(), implode(', ', $methodNames));
             case Failure::UNNECESSARY_CUSTOM_COVERAGE:

--- a/tests/Functional/Command/InspectCommand/Data/checkstyle.xml
+++ b/tests/Functional/Command/InspectCommand/Data/checkstyle.xml
@@ -13,6 +13,6 @@
   <error line="1" column="0" severity="error" message="A custom file coverage is configured at 75%, but the current file coverage 90% exceeds the project coverage 80%. Remove `/home/workspace/test/case/unnecessary-custom-rule.php` from phpfci.xml custom-coverage rules." source="phpunit-file-coverage-inspection"/>
  </file>
  <file name="/home/workspace/test/case/uncovered-method.php">
-  <error line="16" column="0" severity="error" message="File coverage is above 80%, but method(s) `__construct, myMethod` has/have no coverage at all." source="phpunit-file-coverage-inspection"/>
+  <error line="16" column="0" severity="error" message="File coverage is above 80%, but method(s) `__construct` has/have no coverage at all." source="phpunit-file-coverage-inspection"/>
  </file>
 </checkstyle>

--- a/tests/Unit/Renderer/CheckStyleRendererTest.php
+++ b/tests/Unit/Renderer/CheckStyleRendererTest.php
@@ -70,7 +70,7 @@ class CheckStyleRendererTest extends TestCase
     public function testRenderMissingMethodCoverage(): void
     {
         $config  = new InspectionConfig('', 80);
-        $metric  = new FileMetric('/foo/bar/file.php', 85.3, [new MethodMetric('method', 200, 80)]);
+        $metric  = new FileMetric('/foo/bar/file.php', 85.3, [new MethodMetric('method', 200, 0)]);
         $failure = new Failure($metric, 60, Failure::MISSING_METHOD_COVERAGE, 20);
 
         $checkStyle = new CheckStyleRenderer();

--- a/tests/Unit/Renderer/RendererHelperTest.php
+++ b/tests/Unit/Renderer/RendererHelperTest.php
@@ -52,11 +52,11 @@ class RendererHelperTest extends TestCase
      */
     public function testRenderReasonMissingMethodCoverage(): void
     {
-        $metric  = new FileMetric('foobar', 70, [new MethodMetric('myMethod', 100, 80)]);
+        $metric  = new FileMetric('foobar', 70, [new MethodMetric('coveredMethod', 100, 80), new MethodMetric('uncoveredMethod', 105, 0)]);
         $failure = new Failure($metric, 30, Failure::MISSING_METHOD_COVERAGE, 5);
 
         $message = RendererHelper::renderReason($this->config, $failure);
-        static::assertSame('File coverage is above 80%, but method(s) `myMethod` has/have no coverage at all.', $message);
+        static::assertSame('File coverage is above 80%, but method(s) `uncoveredMethod` has/have no coverage at all.', $message);
     }
 
     /**


### PR DESCRIPTION
The uncovered method failure message included all methods of a class instead of just the uncovered methods.