### PR TITLE
Add console renderer

### DIFF
--- a/src/Command/InspectCommand.php
+++ b/src/Command/InspectCommand.php
@@ -10,7 +10,7 @@ use DigitalRevolution\CodeCoverageInspection\Lib\Metrics\MetricsAnalyzer;
 use DigitalRevolution\CodeCoverageInspection\Lib\Utility\FileUtil;
 use DigitalRevolution\CodeCoverageInspection\Renderer\CheckStyleRenderer;
 use DigitalRevolution\CodeCoverageInspection\Renderer\GitlabErrorRenderer;
-use InvalidArgumentException;
+use DigitalRevolution\CodeCoverageInspection\Renderer\TextRenderer;
 use JsonException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -76,7 +76,8 @@ class InspectCommand extends Command
                 FileUtil::writeFile($outputFilePath, (new GitlabErrorRenderer())->render($config, $failures));
                 break;
             default:
-                throw new InvalidArgumentException('Invalid report argument: ' . $input->getOption('report'));
+                $output->write((new TextRenderer())->render($config, $failures));
+                break;
         }
 
         // raise exit code on failure

--- a/src/Renderer/TextRenderer.php
+++ b/src/Renderer/TextRenderer.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\CodeCoverageInspection\Renderer;
+
+use DigitalRevolution\CodeCoverageInspection\Model\Config\InspectionConfig;
+use DigitalRevolution\CodeCoverageInspection\Model\Metric\Failure;
+
+class TextRenderer
+{
+    /**
+     * @param Failure[] $failures
+     */
+    public function render(InspectionConfig $config, array $failures): string
+    {
+        $maxFilePathLength = 0;
+        $lines             = [];
+
+        // gather data
+        foreach ($failures as $failure) {
+            $file              = sprintf('%s:%d', $failure->getMetric()->getFilepath(), $failure->getLineNumber());
+            $lines[]           = [
+                'file'  => $file,
+                'error' => RendererHelper::renderReason($config, $failure)
+            ];
+            $maxFilePathLength = max($maxFilePathLength, strlen($file));
+        }
+
+        // render
+        $result = '';
+        foreach ($lines as $line) {
+            $result .= sprintf('%-' . ($maxFilePathLength + 10) . 's%s' . PHP_EOL, $line['file'], $line['error']);
+        }
+
+        return $result;
+    }
+}

--- a/tests/Unit/Renderer/TextRendererTest.php
+++ b/tests/Unit/Renderer/TextRendererTest.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\CodeCoverageInspection\Tests\Unit\Renderer;
+
+use DigitalRevolution\CodeCoverageInspection\Model\Config\InspectionConfig;
+use DigitalRevolution\CodeCoverageInspection\Model\Metric\Failure;
+use DigitalRevolution\CodeCoverageInspection\Model\Metric\FileMetric;
+use DigitalRevolution\CodeCoverageInspection\Renderer\TextRenderer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \DigitalRevolution\CodeCoverageInspection\Renderer\TextRenderer
+ * @covers ::__construct
+ */
+class TextRendererTest extends TestCase
+{
+    /**
+     * @covers ::render
+     */
+    public function testRenderGlobalCoverageTooLow(): void
+    {
+        $config   = new InspectionConfig('', 80);
+        $failureA = new Failure(new FileMetric('/short/file/path.php', 48.3, []), 80, Failure::GLOBAL_COVERAGE_TOO_LOW, 5);
+        $failureB = new Failure(new FileMetric('/a/medium/file/path.php', 42.5, []), 80, Failure::CUSTOM_COVERAGE_TOO_LOW, 10);
+        $failureC = new Failure(new FileMetric('/a/very/very/long/file/path.php', 67.3, []), 80, Failure::CUSTOM_COVERAGE_TOO_LOW, 200);
+
+        $renderer = new TextRenderer();
+        $result   = $renderer->render($config, [$failureA, $failureB, $failureC]);
+
+        $expected = '/short/file/path.php:5                       ';
+        $expected .= 'Project per file coverage is configured at 80%. Current coverage is at 48.3%. Improve coverage for this class.' . PHP_EOL;
+        $expected .= '/a/medium/file/path.php:10                   ';
+        $expected .= 'Custom file coverage is configured at 80%. Current coverage is at 42.5%. Improve coverage for this class.' . PHP_EOL;
+        $expected .= '/a/very/very/long/file/path.php:200          ';
+        $expected .= 'Custom file coverage is configured at 80%. Current coverage is at 67.3%. Improve coverage for this class.' . PHP_EOL;
+
+        static::assertSame($expected, $result);
+    }
+}

--- a/tests/Unit/Renderer/TextRendererTest.php
+++ b/tests/Unit/Renderer/TextRendererTest.php
@@ -11,7 +11,6 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass \DigitalRevolution\CodeCoverageInspection\Renderer\TextRenderer
- * @covers ::__construct
  */
 class TextRendererTest extends TestCase
 {


### PR DESCRIPTION
Readme.md mentions if no `--report` was specified, the output was written to console. That was actually incorrect. Now added TextRenderer which sends it to the default output.