### PR TITLE
warning when custom coverage is above or equal to global coverage

### DIFF
--- a/src/Lib/Metrics/Inspection/CustomCoverageAboveGlobalInspection.php
+++ b/src/Lib/Metrics/Inspection/CustomCoverageAboveGlobalInspection.php
@@ -24,7 +24,7 @@ class CustomCoverageAboveGlobalInspection extends AbstractInspection
         $customCoverage = $fileConfig->getMinimumCoverage();
 
         // custom coverage is lower than global coverage, and file is above global coverage
-        if ($customCoverage < $globalCoverage && $metric->getCoverage() >= $globalCoverage) {
+        if ($customCoverage <= $globalCoverage && $metric->getCoverage() >= $globalCoverage) {
             return new Failure($metric, $fileConfig->getMinimumCoverage(), Failure::UNNECESSARY_CUSTOM_COVERAGE);
         }
 

--- a/tests/Unit/Lib/Config/ConfigFactoryTest.php
+++ b/tests/Unit/Lib/Config/ConfigFactoryTest.php
@@ -150,7 +150,7 @@ class ConfigFactoryTest extends TestCase
         touch($coveragePath);
 
         $input = $this->createMock(InputInterface::class);
-        $input->expects(self::exactly(5))->method('getOption')->willReturn($configPath, null, null, null);
+        $input->expects(self::exactly(5))->method('getOption')->willReturn($configPath, null, null, null, null);
         $input->expects(self::once())->method('getArgument')->with('coverage')->willReturn([$coveragePath]);
 
         $config = $this->factory->createInspectConfig($input);


### PR DESCRIPTION
Changed the condition checking if the custom coverage entry is useless, to make it also raise an error when the custom coverage is equal to the global coverage
Also fixed a UT issue