### PR TITLE
add the support of multi coverage file for the baseline command + rai…

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ Note: if no `--reportGitlab`, `--reportCheckstyle` or `--reportText` is set, it 
 The third required argument and `--report` has been removed, and should be replaced by:
 `--reportGitlab=<file>`, `--reportCheckstyle=<file>` or `--reportText=<file>` 
 
+# Migrating from 2 to 3
+The baseline now also support multiple coverage files, as the inspect command.
+An error is also raised if the baseline custom entry doesn't match the coverage.
+
 ## About us
 
 At 123inkt (Part of Digital Revolution B.V.), every day more than 50 development professionals are working on improving our internal ERP 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The third required argument and `--report` has been removed, and should be repla
 `--reportGitlab=<file>`, `--reportCheckstyle=<file>` or `--reportText=<file>` 
 
 # Migrating from 2 to 3
-The baseline now also support multiple coverage files, as the inspect command.
+The baseline now also supports multiple coverage files, as the inspect command.
 An error is also raised if the baseline custom entry doesn't match the coverage.
 
 ## About us

--- a/src/Lib/Metrics/Inspection/CustomCoverageAboveGlobalInspection.php
+++ b/src/Lib/Metrics/Inspection/CustomCoverageAboveGlobalInspection.php
@@ -21,10 +21,8 @@ class CustomCoverageAboveGlobalInspection extends AbstractInspection
         }
 
         $globalCoverage = $this->config->getMinimumCoverage();
-        $customCoverage = $fileConfig->getMinimumCoverage();
 
-        // custom coverage is lower than global coverage, and file is above global coverage
-        if ($customCoverage <= $globalCoverage && $metric->getCoverage() >= $globalCoverage) {
+        if ($metric->getCoverage() >= $globalCoverage) {
             return new Failure($metric, $fileConfig->getMinimumCoverage(), Failure::UNNECESSARY_CUSTOM_COVERAGE);
         }
 

--- a/src/Lib/Metrics/Inspection/DifferentCustomCoverageInspection.php
+++ b/src/Lib/Metrics/Inspection/DifferentCustomCoverageInspection.php
@@ -10,12 +10,16 @@ use DigitalRevolution\CodeCoverageInspection\Model\Metric\FileMetric;
 /**
  * File coverage is below custom coverage
  */
-class BelowCustomCoverageInspection extends AbstractInspection
+class DifferentCustomCoverageInspection extends AbstractInspection
 {
     public function inspect(?PathInspectionConfig $fileConfig, FileMetric $metric): ?Failure
     {
-        if ($fileConfig !== null && $metric->getCoverage() < $fileConfig->getMinimumCoverage()) {
+        if ($fileConfig !== null && (int)floor($metric->getCoverage()) < $fileConfig->getMinimumCoverage()) {
             return new Failure($metric, $fileConfig->getMinimumCoverage(), Failure::CUSTOM_COVERAGE_TOO_LOW);
+        }
+
+        if ($fileConfig !== null && (int)floor($metric->getCoverage()) > $fileConfig->getMinimumCoverage()) {
+            return new Failure($metric, $fileConfig->getMinimumCoverage(), Failure::CUSTOM_COVERAGE_TOO_HIGH);
         }
 
         return null;

--- a/src/Lib/Metrics/MetricsAnalyzer.php
+++ b/src/Lib/Metrics/MetricsAnalyzer.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace DigitalRevolution\CodeCoverageInspection\Lib\Metrics;
 
 use DigitalRevolution\CodeCoverageInspection\Lib\Metrics\Inspection\AbstractInspection;
-use DigitalRevolution\CodeCoverageInspection\Lib\Metrics\Inspection\BelowCustomCoverageInspection;
+use DigitalRevolution\CodeCoverageInspection\Lib\Metrics\Inspection\DifferentCustomCoverageInspection;
 use DigitalRevolution\CodeCoverageInspection\Lib\Metrics\Inspection\BelowGlobalCoverageInspection;
 use DigitalRevolution\CodeCoverageInspection\Lib\Metrics\Inspection\CustomCoverageAboveGlobalInspection;
 use DigitalRevolution\CodeCoverageInspection\Lib\Metrics\Inspection\UncoveredMethodsInspection;
@@ -31,10 +31,10 @@ class MetricsAnalyzer
         $this->config  = $config;
 
         $this->inspections = [
-            new BelowCustomCoverageInspection($config),
+            new CustomCoverageAboveGlobalInspection($config),
+            new DifferentCustomCoverageInspection($config),
             new BelowGlobalCoverageInspection($config),
-            new UncoveredMethodsInspection($config),
-            new CustomCoverageAboveGlobalInspection($config)
+            new UncoveredMethodsInspection($config)
         ];
     }
 

--- a/src/Model/Metric/Failure.php
+++ b/src/Model/Metric/Failure.php
@@ -9,6 +9,7 @@ class Failure
     public const CUSTOM_COVERAGE_TOO_LOW     = 2;
     public const UNNECESSARY_CUSTOM_COVERAGE = 3;
     public const MISSING_METHOD_COVERAGE     = 4;
+    public const CUSTOM_COVERAGE_TOO_HIGH     = 5;
 
     private FileMetric $metric;
     private int $minimumCoverage;

--- a/src/Renderer/RendererHelper.php
+++ b/src/Renderer/RendererHelper.php
@@ -20,6 +20,10 @@ class RendererHelper
                 $message = "Custom file coverage is configured at %s%%. Current coverage is at %s%%. Improve coverage for this class.";
 
                 return sprintf($message, (string)$failure->getMinimumCoverage(), (string)$failure->getMetric()->getCoverage());
+            case Failure::CUSTOM_COVERAGE_TOO_HIGH:
+                $message = "Custom file coverage is configured at %s%%. Current coverage is at %s%%. Edit the phpfci baseline for this class.";
+
+                return sprintf($message, (string)$failure->getMinimumCoverage(), (string)$failure->getMetric()->getCoverage());
             case Failure::MISSING_METHOD_COVERAGE:
                 $message     = "File coverage is above %s%%, but method(s) `%s` has/have no coverage at all.";
                 $methodNames = array_filter(

--- a/tests/Functional/Command/BaselineCommand/BaselineCommandTest.php
+++ b/tests/Functional/Command/BaselineCommand/BaselineCommandTest.php
@@ -20,12 +20,6 @@ class BaselineCommandTest extends TestCase
     /** @var vfsStreamDirectory */
     private $fileSystem;
 
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->fileSystem = vfsStream::setup('output');
-    }
-
     /**
      * @throws Exception
      */
@@ -39,7 +33,7 @@ class BaselineCommandTest extends TestCase
 
         // prepare command
         $command = new BaselineCommand();
-        $input   = new ArgvInput(['phpfci', '--baseDir', $baseDir, $coveragePath, $output]);
+        $input   = new ArgvInput(['phpfci', $coveragePath, '--baseDir', $baseDir, '--config', $output]);
         $output  = new BufferedOutput();
 
         // run test case
@@ -52,5 +46,11 @@ class BaselineCommandTest extends TestCase
         $result     = $resultFile->getContent();
 
         static::assertSame($expected, $result);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->fileSystem = vfsStream::setup('output');
     }
 }

--- a/tests/Functional/Command/InspectCommand/Data/checkstyle.xml
+++ b/tests/Functional/Command/InspectCommand/Data/checkstyle.xml
@@ -4,7 +4,10 @@
   <error line="1" column="0" severity="error" message="Project per file coverage is configured at 80%. Current coverage is at 70%. Improve coverage for this class." source="phpunit-file-coverage-inspection"/>
  </file>
  <file name="/home/workspace/test/directory/standard-below-threshold.php">
-  <error line="1" column="0" severity="error" message="Custom file coverage is configured at 90%. Current coverage is at 80%. Improve coverage for this class." source="phpunit-file-coverage-inspection"/>
+  <error line="1" column="0" severity="error" message="Custom file coverage is configured at 90%. Current coverage is at 60%. Improve coverage for this class." source="phpunit-file-coverage-inspection"/>
+ </file>
+ <file name="/home/workspace/test/directory/standard-above-threshold.php">
+  <error line="1" column="0" severity="error" message="A custom file coverage is configured at 90%, but the current file coverage 90% exceeds the project coverage 80%. Remove `/home/workspace/test/directory/standard-above-threshold.php` from phpfci.xml custom-coverage rules." source="phpunit-file-coverage-inspection"/>
  </file>
  <file name="/home/workspace/test/case/below-threshold.php">
   <error line="1" column="0" severity="error" message="Custom file coverage is configured at 55%. Current coverage is at 50%. Improve coverage for this class." source="phpunit-file-coverage-inspection"/>

--- a/tests/Functional/Command/InspectCommand/Data/coverage.xml
+++ b/tests/Functional/Command/InspectCommand/Data/coverage.xml
@@ -62,13 +62,13 @@
                      conditionals="0"
                      coveredconditionals="0"
                      statements="10"
-                     coveredstatements="8"
+                     coveredstatements="6"
                      elements="0"
                      coveredelements="0"/>
             <line num="1" type="method" name="methodName" count="1"/>
-            <line num="2" type="stmt" count="1"/>
+            <line num="2" type="stmt" count="0"/>
             <line num="3" type="stmt" count="1"/>
-            <line num="4" type="stmt" count="1"/>
+            <line num="4" type="stmt" count="0"/>
             <line num="5" type="stmt" count="1"/>
             <line num="6" type="stmt" count="1"/>
             <line num="7" type="stmt" count="1"/>

--- a/tests/Unit/Lib/Metrics/Inspection/CustomCoverageAboveGlobalInspectionTest.php
+++ b/tests/Unit/Lib/Metrics/Inspection/CustomCoverageAboveGlobalInspectionTest.php
@@ -47,13 +47,4 @@ class CustomCoverageAboveGlobalInspectionTest extends TestCase
         static::assertSame(Failure::UNNECESSARY_CUSTOM_COVERAGE, $failure->getReason());
         static::assertSame(40, $failure->getMinimumCoverage());
     }
-
-    public function testInspectCoverageCustomCoverageAboveGlobalCoverageShouldPass(): void
-    {
-        // global is 80
-        $fileConfig = new PathInspectionConfig(PathInspectionConfig::TYPE_FILE, '/tmp/b', 85);
-        $metric     = new FileMetric('/tmp/b/', 0, 83, [], []);
-
-        static::assertNull($this->inspection->inspect($fileConfig, $metric));
-    }
 }

--- a/tests/Unit/Lib/Metrics/Inspection/DifferentCustomCoverageInspectionTest.php
+++ b/tests/Unit/Lib/Metrics/Inspection/DifferentCustomCoverageInspectionTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace DigitalRevolution\CodeCoverageInspection\Tests\Unit\Lib\Metrics\Inspection;
 
 use DigitalRevolution\CodeCoverageInspection\Lib\Metrics\Inspection\AbstractInspection;
-use DigitalRevolution\CodeCoverageInspection\Lib\Metrics\Inspection\BelowCustomCoverageInspection;
+use DigitalRevolution\CodeCoverageInspection\Lib\Metrics\Inspection\DifferentCustomCoverageInspection;
 use DigitalRevolution\CodeCoverageInspection\Model\Config\InspectionConfig;
 use DigitalRevolution\CodeCoverageInspection\Model\Config\PathInspectionConfig;
 use DigitalRevolution\CodeCoverageInspection\Model\Metric\Failure;
@@ -12,16 +12,16 @@ use DigitalRevolution\CodeCoverageInspection\Model\Metric\FileMetric;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
-#[CoversClass(BelowCustomCoverageInspection::class)]
+#[CoversClass(DifferentCustomCoverageInspection::class)]
 #[CoversClass(AbstractInspection::class)]
-class BelowCustomCoverageInspectionTest extends TestCase
+class DifferentCustomCoverageInspectionTest extends TestCase
 {
-    private BelowCustomCoverageInspection $inspection;
+    private DifferentCustomCoverageInspection $inspection;
 
     protected function setUp(): void
     {
         $config           = new InspectionConfig('/tmp/', 80);
-        $this->inspection = new BelowCustomCoverageInspection($config);
+        $this->inspection = new DifferentCustomCoverageInspection($config);
     }
 
     public function testInspectNoCustomCoverageShouldPass(): void
@@ -43,10 +43,24 @@ class BelowCustomCoverageInspectionTest extends TestCase
         static::assertSame(40, $failure->getMinimumCoverage());
     }
 
-    public function testInspectCoverageAboveCustomCoverageShouldPass(): void
+    /**
+     * Custom coverage 40%
+     */
+    public function testInspectCoverageAboveCustomCoverageShouldFail(): void
     {
-        $fileConfig = new PathInspectionConfig(PathInspectionConfig::TYPE_FILE, '/tmp/b', 40);
-        $metric     = new FileMetric('/tmp/a/', 0, 60, [], []);
+        $fileConfig = new PathInspectionConfig(PathInspectionConfig::TYPE_FILE, '/tmp/b', 20);
+        $metric     = new FileMetric('/tmp/a/', 0, 40, [], []);
+
+        $failure = $this->inspection->inspect($fileConfig, $metric);
+        static::assertNotNull($failure);
+        static::assertSame(Failure::CUSTOM_COVERAGE_TOO_HIGH, $failure->getReason());
+        static::assertSame(20, $failure->getMinimumCoverage());
+    }
+
+    public function testInspectCoverageCustomCoverageShouldPass(): void
+    {
+        $fileConfig = new PathInspectionConfig(PathInspectionConfig::TYPE_FILE, '/tmp/b', 50);
+        $metric     = new FileMetric('/tmp/a/', 0, 50.8, [], []);
 
         static::assertNull($this->inspection->inspect($fileConfig, $metric));
     }

--- a/tests/Unit/Lib/Metrics/MetricsAnalyzerTest.php
+++ b/tests/Unit/Lib/Metrics/MetricsAnalyzerTest.php
@@ -41,7 +41,7 @@ class MetricsAnalyzerTest extends TestCase
     {
         $metrics[] = new FileMetric('/a/b/c/test.php', 0, 45, [], []);
         $config    = new InspectionConfig('/a/', 80, false);
-        $config->addPathInspection(new PathInspectionConfig(PathInspectionConfig::TYPE_FILE, 'b/c/test.php', 40));
+        $config->addPathInspection(new PathInspectionConfig(PathInspectionConfig::TYPE_FILE, 'b/c/test.php', 45));
 
         $analyzer = new MetricsAnalyzer($metrics, $config);
         $result   = $analyzer->analyze();
@@ -66,12 +66,12 @@ class MetricsAnalyzerTest extends TestCase
         $metric  = new FileMetric('/a/b/c/test.php', 0, 90, [], []);
         $metrics = [$metric];
         $config  = new InspectionConfig('/a/', 80, false);
-        $config->addPathInspection(new PathInspectionConfig(PathInspectionConfig::TYPE_FILE, 'b/c/test.php', 50));
+        $config->addPathInspection(new PathInspectionConfig(PathInspectionConfig::TYPE_FILE, 'b/c/test.php', 90));
 
         $analyzer = new MetricsAnalyzer($metrics, $config);
         $result   = $analyzer->analyze();
         static::assertCount(1, $result);
-        static::assertEquals([new Failure($metric, 50, Failure::UNNECESSARY_CUSTOM_COVERAGE)], $result);
+        static::assertEquals([new Failure($metric, 90, Failure::UNNECESSARY_CUSTOM_COVERAGE)], $result);
     }
 
     public function testAnalyzeFileWithUncoveredMethodsShouldFail(): void

--- a/tests/Unit/Renderer/RendererHelperTest.php
+++ b/tests/Unit/Renderer/RendererHelperTest.php
@@ -17,11 +17,6 @@ class RendererHelperTest extends TestCase
 {
     private InspectionConfig $config;
 
-    protected function setUp(): void
-    {
-        $this->config = new InspectionConfig('base-path', 80);
-    }
-
     public function testRenderReasonGlobalCoverageTooLow(): void
     {
         $metric  = new FileMetric('foobar', 0, 80, [], []);
@@ -38,6 +33,18 @@ class RendererHelperTest extends TestCase
 
         $message = RendererHelper::renderReason($this->config, $failure);
         static::assertSame('Custom file coverage is configured at 30%. Current coverage is at 70%. Improve coverage for this class.', $message);
+    }
+
+    public function testRenderReasonCustomCoverageTooHigh(): void
+    {
+        $metric  = new FileMetric('foobar', 0, 50, [], []);
+        $failure = new Failure($metric, 70, Failure::CUSTOM_COVERAGE_TOO_HIGH, 5);
+
+        $message = RendererHelper::renderReason($this->config, $failure);
+        static::assertSame(
+            'Custom file coverage is configured at 70%. Current coverage is at 50%. Edit the phpfci baseline for this class.',
+            $message
+        );
     }
 
     public function testRenderReasonMissingMethodCoverage(): void
@@ -69,5 +76,10 @@ class RendererHelperTest extends TestCase
 
         $this->expectException(RuntimeException::class);
         RendererHelper::renderReason($this->config, $failure);
+    }
+
+    protected function setUp(): void
+    {
+        $this->config = new InspectionConfig('base-path', 80);
     }
 }


### PR DESCRIPTION
In a previous feature, we added the support for multiple coverage files to the inspect command.
Though this change wasn't also made for the baseline command which is now making it very difficult to generate the baselines when the coverage is split in multiple files.

Also, in an attempt to keep our baselines clean and up-to-date, so we can have a better overview, I've changed the behavior when the coverage doesn't match the custom coverage set in the baseline. Previously an error was raised only if the coverage was below the custom coverage in the baseline, it is also now raising an error when the coverage is above the custom coverage in the baseline. 