### PR TITLE
Fixes deprecation notices

### DIFF
--- a/src/Command/InspectCommand.php
+++ b/src/Command/InspectCommand.php
@@ -28,9 +28,9 @@ class InspectCommand extends Command
     private ConfigFactory $configFactory;
     private string $schemaPath;
 
-    public function __construct(string $name = null)
+    public function __construct()
     {
-        parent::__construct($name);
+        parent::__construct();
         $this->configFactory = new ConfigFactory();
         $this->schemaPath    = dirname(__DIR__, 2) . '/resources/phpfci.xsd';
     }


### PR DESCRIPTION
Fixes warning:
```
PHP Deprecated:  DigitalRevolution\CodeCoverageInspection\Command\InspectCommand::__construct(): 
Implicitly marking parameter $name as nullable is deprecated, the explicit nullable type must be used 
instead in /home/runner/work/symfony-log-viewer-bundle/symfony-log-viewer-bundle/vendor/digitalrevolution/phpunit-file-coverage-inspection/src/Command/InspectCommand.php on line 31
```