### PR TITLE
Fix implicit null warning in php 8.4

### DIFF
--- a/src/Command/InspectCommand.php
+++ b/src/Command/InspectCommand.php
@@ -28,7 +28,7 @@ class InspectCommand extends Command
     private ConfigFactory $configFactory;
     private string $schemaPath;
 
-    public function __construct(string $name = null)
+    public function __construct(?string $name = null)
     {
         parent::__construct($name);
         $this->configFactory = new ConfigFactory();


### PR DESCRIPTION
Fixes implicit null warning in php 8.4

Deprecated: DigitalRevolution\CodeCoverageInspection\Command\InspectCommand::__construct(): Implicitly marking parameter $name as nullable is deprecated, the explicit nullable type must be used instead